### PR TITLE
update DRS URI prefix

### DIFF
--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -1176,7 +1176,7 @@ type QueryType {
     co.cohort_description as cohort_description,
     a.arm as arm,
     collect(DISTINCT o.case_id) AS other_cases,
-    'https://nci-crdc.datacommons.io/ga4gh/drs/v1/objects/dg.4DFC/' AS drs_prefix
+    'drs://nci-crdc.datacommons.io/dg.4DFC/' AS drs_prefix
     RETURN{
     file_name: file_name,
     file_type: file_type,
@@ -1311,7 +1311,7 @@ type QueryType {
     co.cohort_description as cohort_description,
     a.arm as arm,
     collect(DISTINCT o.case_id) AS other_cases,
-    'https://nci-crdc.datacommons.io/ga4gh/drs/v1/objects/dg.4DFC/' AS drs_prefix
+    'drs://nci-crdc.datacommons.io/dg.4DFC/' AS drs_prefix
     RETURN{
     file_name: file_name,
     file_type: file_type,

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -685,7 +685,7 @@ type QueryType {
     co.cohort_description as cohort_description,
     a.arm as arm,
     collect(DISTINCT o.case_id) AS other_cases,
-    'https://nci-crdc.datacommons.io/ga4gh/drs/v1/objects/dg.4DFC/' AS drs_prefix
+    'drs://nci-crdc.datacommons.io/dg.4DFC/' AS drs_prefix
     RETURN{
     file_name: file_name,
     file_type: file_type,
@@ -820,7 +820,7 @@ type QueryType {
     co.cohort_description as cohort_description,
     a.arm as arm,
     collect(DISTINCT o.case_id) AS other_cases,
-    'https://nci-crdc.datacommons.io/ga4gh/drs/v1/objects/dg.4DFC/' AS drs_prefix
+    'drs://nci-crdc.datacommons.io/dg.4DFC/' AS drs_prefix
     RETURN{
     file_name: file_name,
     file_type: file_type,


### PR DESCRIPTION
- update DRS URI prefix to match what was specified in 8/15 email from Miloš Trboljevac:

```
For example, instead of:
https://nci-crdc.datacommons.io/ga4gh/drs/v1/objects/dg.4DFC/bf7ae08f-0afe-5aa5-969a-de9a17ac0f2f
there should be this value:
drs://nci-crdc.datacommons.io/dg.4DFC/bf7ae08f-0afe-5aa5-969a-de9a17ac0f2f
```