### PR TITLE
update sample index mapping types to fix query errors

### DIFF
--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -434,8 +434,8 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         Map<String, Object> formattedParams = formatParams(params, "case_ids", "case_id_lc");
 
         final String[][] PROPERTIES = new String[][]{
-                new String[]{"sample_id", "sample_id_kw"},
-                new String[]{"case_id", "case_id_kw"},
+                new String[]{"sample_id", "sample_ids"},
+                new String[]{"case_id", "case_ids"},
                 new String[]{"case_id_lc", "case_id_lc"},
                 new String[]{"breed", "breed"},
                 new String[]{"diagnosis", "diagnosis"},
@@ -448,8 +448,8 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 new String[]{"necropsy_sample", "necropsy_sample"},
                 new String[]{"sample_preservation", "sample_preservation"},
                 new String[]{"files", "files"},
-                new String[]{"physical_sample_type", "physical_sample_type_kw"},
-                new String[]{"general_sample_pathology", "general_sample_pathology_kw"},
+                new String[]{"physical_sample_type", "physical_sample_type"},
+                new String[]{"general_sample_pathology", "general_sample_pathology"},
                 new String[]{"tumor_sample_origin", "tumor_sample_origin"},
                 new String[]{"comment", "comment"},
                 new String[]{"individual_id", "individual_id"},
@@ -473,11 +473,11 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 new String[]{"arm", "arm"}
         };
 
-        String defaultSort = "sample_id_kw"; // Default sort order
+        String defaultSort = "sample_ids"; // Default sort order
 
         Map<String, String> mapping = Map.ofEntries(
-                Map.entry("sample_id", "sample_id_kw"),
-                Map.entry("case_id", "case_id_kw"),
+                Map.entry("sample_id", "sample_ids"),
+                Map.entry("case_id", "case_ids"),
                 Map.entry("breed", "breed"),
                 Map.entry("diagnosis", "diagnosis"),
                 Map.entry("sample_site", "sample_site"),
@@ -546,7 +546,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 new String[]{"other_cases", "other_cases"}
         };
 
-        String defaultSort = "file_name_kw"; // Default sort order
+        String defaultSort = "file_name"; // Default sort order
 
         Map<String, String> mapping = Map.ofEntries(
                 Map.entry("file_name", "file_name"),
@@ -697,17 +697,17 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 GS_COUNT_ENDPOINT, SAMPLES_COUNT_END_POINT,
                 GS_COUNT_RESULT_FIELD, "sample_count",
                 GS_RESULT_FIELD, "samples",
-                GS_SEARCH_FIELD, List.of("sample_ids", "program_name", "clinical_study_designation",
-                    "case_id", "sample_site_txt", "physical_sample_type", "general_sample_pathology"),
-                GS_SORT_FIELD, "sample_id_kw",
+                GS_SEARCH_FIELD, List.of("sample_ids_txt", "program_name", "clinical_study_designation",
+                    "case_ids_txt", "sample_site_txt", "physical_sample_type_txt", "general_sample_pathology_txt"),
+                GS_SORT_FIELD, "sample_ids",
                 GS_COLLECT_FIELDS, new String[][]{
-                        new String[]{"sample_id", "sample_ids"},
+                        new String[]{"sample_id", "sample_ids_txt"},
                         new String[]{"program_name", "program_name"},
                         new String[]{"clinical_study_designation", "clinical_study_designation"},
-                        new String[]{"case_id", "case_ids"},
+                        new String[]{"case_id", "case_ids_txt"},
                         new String[]{"sample_site", "sample_site_txt"},
-                        new String[]{"physical_sample_type", "physical_sample_type"},
-                        new String[]{"general_sample_pathology", "general_sample_pathology"}
+                        new String[]{"physical_sample_type", "physical_sample_type_txt"},
+                        new String[]{"general_sample_pathology", "general_sample_pathology_txt"}
                 },
                 GS_CATEGORY_TYPE, "sample"
         ));

--- a/src/main/resources/yaml/es_indices_icdc.yml
+++ b/src/main/resources/yaml/es_indices_icdc.yml
@@ -209,15 +209,15 @@ Indices:
         type: keyword
 
       case_ids:
-        type: text
-      case_id_kw:
         type: keyword
+      case_ids_txt:
+        type: text
       case_id_lc:
         type: keyword
       sample_ids:
-        type: text
-      sample_id_kw:
         type: keyword
+      sample_ids_txt:
+        type: text
 
       program_name:
         type: text
@@ -228,13 +228,13 @@ Indices:
       sample_site_txt:
         type: text
       physical_sample_type:
-        type: text
-      physical_sample_type_kw:
         type: keyword
+      physical_sample_type_txt:
+        type: text
       general_sample_pathology:
-        type: text
-      general_sample_pathology_kw:
         type: keyword
+      general_sample_pathology_txt:
+        type: text
       tumor_grade:
         type: keyword
       sample_chronology:
@@ -334,10 +334,10 @@ Indices:
       COLLECT(DISTINCT f.file_format) + study_file_formats AS file_format,
 
       c.case_id AS case_ids,
-      c.case_id AS case_id_kw,
+      c.case_id AS case_ids_txt,
       toLower(c.case_id) AS case_id_lc,
       samp.sample_id AS sample_ids,
-      samp.sample_id AS sample_id_kw,
+      samp.sample_id AS sample_ids_txt,
 
       samp.tumor_grade as tumor_grade,
       samp.sample_chronology as sample_chronology,
@@ -345,9 +345,9 @@ Indices:
       samp.necropsy_sample as necropsy_sample,
       samp.sample_preservation as sample_preservation,
       samp.physical_sample_type as physical_sample_type,
-      samp.physical_sample_type as physical_sample_type_kw,
+      samp.physical_sample_type as physical_sample_type_txt,
       samp.general_sample_pathology as general_sample_pathology,
-      samp.general_sample_pathology as general_sample_pathology_kw,
+      samp.general_sample_pathology as general_sample_pathology_txt,
       samp.tumor_sample_origin as tumor_sample_origin,
       samp.comment as comment,
 


### PR DESCRIPTION
- change sample index mapping types to "keyword" to fix errors executing sample-related query
- this is a continuation of https://github.com/CBIIT/bento-icdc-backend/pull/13 (there was a comment on the ticket that specified this also needed addressed/fixed, but I didn't see it...)