### PR TITLE
Clinical data node query/schema updates

### DIFF
--- a/src/main/resources/graphql/icdc-doc.graphql
+++ b/src/main/resources/graphql/icdc-doc.graphql
@@ -905,9 +905,10 @@ type CycleNodeData {
 }
 
 type VisitNodeData {
-    inferred: Boolean
-    visit_id: String
+    case_id: String
     visit_date: String
+    visit_number: Int
+    visit_id: String
 }
 
 type FollowUpNodeData {
@@ -1006,11 +1007,14 @@ type PriorSurgeryNodeData {
 }
 
 type PhysicalExamNodeData {
+    visit_id: String
     date_of_examination: String
-    pe_comment: String
+    day_in_cycle: Int
     body_system: String
-    case_id: String
     pe_finding: String
+    pe_comment: String
+    phase_pe: Int
+    assessment_timepoint: Int
 }
 
 type AgentNodeData {
@@ -1019,7 +1023,8 @@ type AgentNodeData {
 }
 
 type DiseaseExtentNodeData {
-    lesion_number: String
+    case_id: String
+    lesion_number: Int
     lesion_site: String
     lesion_description: String
     previously_irradiated: String
@@ -1029,7 +1034,7 @@ type DiseaseExtentNodeData {
     date_of_evaluation: String
     measured_how: String
     longest_measurement: String
-    evaluation_number: String
+    evaluation_number: Int
     evaluation_code: String
 }
 

--- a/src/main/resources/graphql/icdc-doc.graphql
+++ b/src/main/resources/graphql/icdc-doc.graphql
@@ -998,6 +998,7 @@ type PriorTherapyNodeData {
 }
 
 type PriorSurgeryNodeData {
+    case_id: String
     date_of_surgery: String
     procedure: String
     anatomical_site_of_surgery: String

--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -905,9 +905,10 @@ type CycleNodeData {
 }
 
 type VisitNodeData {
-    inferred: Boolean
-    visit_id: String
+    case_id: String
     visit_date: String
+    visit_number: Int
+    visit_id: String
 }
 
 type FollowUpNodeData {
@@ -1006,11 +1007,14 @@ type PriorSurgeryNodeData {
 }
 
 type PhysicalExamNodeData {
+    visit_id: String
     date_of_examination: String
-    pe_comment: String
+    day_in_cycle: Int
     body_system: String
-    case_id: String
     pe_finding: String
+    pe_comment: String
+    phase_pe: Int
+    assessment_timepoint: Int
 }
 
 type AgentNodeData {
@@ -1019,7 +1023,8 @@ type AgentNodeData {
 }
 
 type DiseaseExtentNodeData {
-    lesion_number: String
+    case_id: String
+    lesion_number: Int
     lesion_site: String
     lesion_description: String
     previously_irradiated: String
@@ -1029,7 +1034,7 @@ type DiseaseExtentNodeData {
     date_of_evaluation: String
     measured_how: String
     longest_measurement: String
-    evaluation_number: String
+    evaluation_number: Int
     evaluation_code: String
 }
 
@@ -2065,7 +2070,14 @@ type QueryType {
     WHERE s.clinical_study_designation = $study_code
     MATCH (s)<-[*1..2]-(c:case)
     MATCH (c)<-[*1..2]-(v:visit)
-    RETURN DISTINCT v {.*}
+    WITH DISTINCT v, c
+    RETURN {
+    case_id: c.case_id,
+    visit_date: v.visit_date,
+    visit_number: v.visit_number,
+    visit_id: v.visit_id
+    }
+    ORDER BY c.case_id
     """, passThrough: true)
 
     followUpNodeData(study_code: String!): [FollowUpNodeData] @cypher(statement: """
@@ -2138,7 +2150,17 @@ type QueryType {
     MATCH (s)<-[*1..2]-(c:case)
     MATCH (c)<-[:of_case]-(e:enrollment)
     MATCH (e)<-[:at_enrollment]-(ps:prior_surgery)
-    RETURN DISTINCT ps {.*}
+    WITH DISTINCT c, ps
+    RETURN {
+    case_id: c.case_id,
+    date_of_surgery: ps.date_of_surgery,
+    procedure: ps.procedure,
+    anatomical_site_of_surgery: ps.anatomical_site_of_surgery,
+    surgical_finding: ps.surgical_finding,
+    residual_disease: ps.residual_disease,
+    therapeutic_indicator: ps.therapeutic_indicator
+    }
+    ORDER BY c.case_id
     """, passThrough: true)
 
     agentAdministrationNodeData(study_code: String!): [AgentAdministrationNodeData] @cypher(statement: """
@@ -2156,7 +2178,18 @@ type QueryType {
     MATCH (s)<-[*1..2]-(c:case)
     MATCH (c)<-[*1..2]-(v:visit)
     MATCH (v)<-[:on_visit]-(pe:physical_exam)
-    RETURN DISTINCT pe {.*}
+    WITH DISTINCT pe, v
+    RETURN {
+    visit_id: v.visit_id,
+    date_of_examination: pe.date_of_examination,
+    day_in_cycle: pe.day_in_cycle,
+    body_system: pe.body_system,
+    pe_finding: pe.pe_finding,
+    pe_comment: pe.pe_comment,
+    phase_pe: pe.phase_pe,
+    assessment_timepoint: pe.assessment_timepoint
+    }
+    ORDER BY v.visit_id
     """, passThrough: true)
 
     vitalSignsNodeData(study_code: String!): [VitalSignsNodeData] @cypher(statement: """
@@ -2174,7 +2207,23 @@ type QueryType {
     MATCH (s)<-[*1..2]-(c:case)
     MATCH (c)<-[*1..2]-(v:visit)
     MATCH (v)<-[:on_visit]-(de:disease_extent)
-    RETURN DISTINCT de {.*}
+    WITH DISTINCT de, c
+    RETURN {
+    case_id: c.case_id,
+    lesion_number: de.lesion_number,
+    lesion_site: de.lesion_site,
+    lesion_description: de.lesion_description,
+    previously_irradiated: de.previously_irradiated,
+    previously_treated: de.previously_treated,
+    measurable_lesion: de.measurable_lesion,
+    target_lesion: de.target_lesion,
+    date_of_evaluation: de.date_of_evaluation,
+    measured_how: de.measured_how,
+    longest_measurement: de.longest_measurement,
+    evaluation_number: de.evaluation_number,
+    evaluation_code: de.evaluation_code
+    }
+    ORDER BY c.case_id
     """, passThrough: true)
 
     labExamNodeData(study_code: String!): [LabExamNodeData] @cypher(statement: """

--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -998,6 +998,7 @@ type PriorTherapyNodeData {
 }
 
 type PriorSurgeryNodeData {
+    case_id: String
     date_of_surgery: String
     procedure: String
     anatomical_site_of_surgery: String

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -414,6 +414,7 @@ type CycleNodeData {
 }
 
 type VisitNodeData {
+    case_id: String
     visit_date: String
     visit_number: Int
     visit_id: String
@@ -1578,12 +1579,14 @@ type QueryType {
     WHERE s.clinical_study_designation = $study_code
     MATCH (s)<-[*1..2]-(c:case)
     MATCH (c)<-[*1..2]-(v:visit)
-    WITH DISTINCT v
+    WITH DISTINCT v, c
     RETURN {
+    case_id: c.case_id,
     visit_date: v.visit_date,
     visit_number: v.visit_number,
     visit_id: v.visit_id
     }
+    ORDER BY v.visit_id
     """, passThrough: true)
 
     followUpNodeData(study_code: String!): [FollowUpNodeData] @cypher(statement: """

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -1586,7 +1586,7 @@ type QueryType {
     visit_number: v.visit_number,
     visit_id: v.visit_id
     }
-    ORDER BY v.visit_id
+    ORDER BY c.case_id
     """, passThrough: true)
 
     followUpNodeData(study_code: String!): [FollowUpNodeData] @cypher(statement: """

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -507,6 +507,7 @@ type PriorTherapyNodeData {
 }
 
 type PriorSurgeryNodeData {
+    case_id: String
     date_of_surgery: String
     procedure: String
     anatomical_site_of_surgery: String

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -414,9 +414,9 @@ type CycleNodeData {
 }
 
 type VisitNodeData {
-    inferred: Boolean
-    visit_id: String
     visit_date: String
+    visit_number: Int
+    visit_id: String
 }
 
 type FollowUpNodeData {
@@ -1574,7 +1574,12 @@ type QueryType {
     WHERE s.clinical_study_designation = $study_code
     MATCH (s)<-[*1..2]-(c:case)
     MATCH (c)<-[*1..2]-(v:visit)
-    RETURN DISTINCT v {.*}
+    WITH DISTINCT v
+    RETURN {
+    visit_date: v.visit_date,
+    visit_number: v.visit_number,
+    visit_id: v.visit_id
+    }
     """, passThrough: true)
 
     followUpNodeData(study_code: String!): [FollowUpNodeData] @cypher(statement: """
@@ -1675,7 +1680,18 @@ type QueryType {
     MATCH (s)<-[*1..2]-(c:case)
     MATCH (c)<-[*1..2]-(v:visit)
     MATCH (v)<-[:on_visit]-(pe:physical_exam)
-    RETURN DISTINCT pe {.*}
+    WITH DISTINCT pe, v
+    RETURN {
+    visit_id: v.visit_id,
+    date_of_examination: pe.date_of_examination,
+    day_in_cycle: pe.day_in_cycle,
+    body_system: pe.body_system,
+    pe_finding: pe.pe_finding,
+    pe_comment: pe.pe_comment,
+    phase_pe: pe.phase_pe,
+    assessment_timepoint: pe.assessment_timepoint
+    }
+    ORDER BY v.visit_id
     """, passThrough: true)
 
     vitalSignsNodeData(study_code: String!): [VitalSignsNodeData] @cypher(statement: """

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -515,11 +515,14 @@ type PriorSurgeryNodeData {
 }
 
 type PhysicalExamNodeData {
+    visit_id: String
     date_of_examination: String
-    pe_comment: String
+    day_in_cycle: Int
     body_system: String
-    case_id: String
     pe_finding: String
+    pe_comment: String
+    phase_pe: Int
+    assessment_timepoint: Int
 }
 
 type AgentNodeData {

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -1647,7 +1647,17 @@ type QueryType {
     MATCH (s)<-[*1..2]-(c:case)
     MATCH (c)<-[:of_case]-(e:enrollment)
     MATCH (e)<-[:at_enrollment]-(ps:prior_surgery)
-    RETURN DISTINCT ps {.*}
+    WITH DISTINCT c, ps
+    RETURN {
+    case_id: c.case_id,
+    date_of_surgery: ps.date_of_surgery,
+    procedure: ps.procedure,
+    anatomical_site_of_surgery: ps.anatomical_site_of_surgery,
+    surgical_finding: ps.surgical_finding,
+    residual_disease: ps.residual_disease,
+    therapeutic_indicator: ps.therapeutic_indicator
+    }
+    ORDER BY c.case_id
     """, passThrough: true)
 
     agentAdministrationNodeData(study_code: String!): [AgentAdministrationNodeData] @cypher(statement: """

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -531,7 +531,8 @@ type AgentNodeData {
 }
 
 type DiseaseExtentNodeData {
-    lesion_number: String
+    case_id: String
+    lesion_number: Int
     lesion_site: String
     lesion_description: String
     previously_irradiated: String
@@ -541,7 +542,7 @@ type DiseaseExtentNodeData {
     date_of_evaluation: String
     measured_how: String
     longest_measurement: String
-    evaluation_number: String
+    evaluation_number: Int
     evaluation_code: String
 }
 
@@ -1712,7 +1713,23 @@ type QueryType {
     MATCH (s)<-[*1..2]-(c:case)
     MATCH (c)<-[*1..2]-(v:visit)
     MATCH (v)<-[:on_visit]-(de:disease_extent)
-    RETURN DISTINCT de {.*}
+    WITH DISTINCT de, c
+    RETURN {
+    case_id: c.case_id,
+    lesion_number: de.lesion_number,
+    lesion_site: de.lesion_site,
+    lesion_description: de.lesion_description,
+    previously_irradiated: de.previously_irradiated,
+    previously_treated: de.previously_treated,
+    measurable_lesion: de.measurable_lesion,
+    target_lesion: de.target_lesion,
+    date_of_evaluation: de.date_of_evaluation,
+    measured_how: de.measured_how,
+    longest_measurement: de.longest_measurement,
+    evaluation_number: de.evaluation_number,
+    evaluation_code: de.evaluation_code
+    }
+    ORDER BY c.case_id
     """, passThrough: true)
 
     labExamNodeData(study_code: String!): [LabExamNodeData] @cypher(statement: """


### PR DESCRIPTION
- return `case_id` in `prior_surgery`, `visit` and `disease_extent` node queries
- add missing fields/properties to `visit` and `physical_exam` types/queries

(PR combines [ICDC-3481](https://tracker.nci.nih.gov/browse/ICDC-3481), [ICDC-3483](https://tracker.nci.nih.gov/browse/ICDC-3483), [ICDC-3484](https://tracker.nci.nih.gov/browse/ICDC-3484), [ICDC-3485](https://tracker.nci.nih.gov/browse/ICDC-3485) and [ICDC-3488](https://tracker.nci.nih.gov/browse/ICDC-3488))