### PR TITLE
add non-relationship fields to assay/image/lab_exam objects

### DIFF
--- a/src/main/resources/graphql/icdc-doc.graphql
+++ b/src/main/resources/graphql/icdc-doc.graphql
@@ -73,7 +73,8 @@ type agent_administration {
 type assay {
   sample: sample 
   files: [file] 
-  images: [image] 
+  images: [image]
+  schema_validation_placeholder: String 
 }
 
 type biospecimen_source {
@@ -227,7 +228,8 @@ type follow_up {
 }
 
 type image {
-  assay: assay 
+  assay: assay
+  schema_validation_placeholder: String
 }
 
 type image_collection {
@@ -240,7 +242,8 @@ type image_collection {
 }
 
 type lab_exam {
-  visit: visit 
+  visit: visit
+  schema_validation_placeholder: String
 }
 
 type off_study {

--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -74,6 +74,7 @@ type assay {
   sample: sample @relation(name:"of_sample", direction:OUT)
   files: [file] @relation(name:"of_assay", direction:IN)
   images: [image] @relation(name:"of_assay", direction:IN)
+  schema_validation_placeholder: String
 }
 
 type biospecimen_source {
@@ -228,6 +229,7 @@ type follow_up {
 
 type image {
   assay: assay @relation(name:"of_assay", direction:OUT)
+  schema_validation_placeholder: String
 }
 
 type image_collection {
@@ -241,6 +243,7 @@ type image_collection {
 
 type lab_exam {
   visit: visit @relation(name:"on_visit", direction:OUT)
+  schema_validation_placeholder: String
 }
 
 type off_study {


### PR DESCRIPTION
- objects that only contain relationships to other objects in the schema (see below example) cause schema validation errors when opening the Documentation Explorer on the ICDC GraphiQL page

```gql
type assay {
  sample: sample @relation(name:"of_sample", direction:OUT)
  files: [file] @relation(name:"of_assay", direction:IN)
  images: [image] @relation(name:"of_assay", direction:IN)
}
```

- adding a non-relationship placeholder field to the object resolves any schema validation errors

```gql
type assay {
  sample: sample @relation(name:"of_sample", direction:OUT)
  files: [file] @relation(name:"of_assay", direction:IN)
  images: [image] @relation(name:"of_assay", direction:IN)
  schema_validation_placeholder: String
}
```