### PR TITLE
opensearch query supporting table text search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,13 @@
 			<artifactId>json</artifactId>
 			<version>20231013</version>
 		</dependency>
+
+		<!-- dev tools  -->
+		<dependency>
+        	<groupId>org.springframework.boot</groupId>
+        	<artifactId>spring-boot-devtools</artifactId>
+        	<optional>true</optional>
+    	</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -259,7 +259,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         Map<String, Object> query = esService.buildFacetFilterQuery(formattedParams, Set.of(), Set.of("first", FILTER_TEXT));
         if (!formattedParams.get(FILTER_TEXT).toString().isEmpty()) {
             String filterText = formattedParams.get(FILTER_TEXT).toString();
-            query = buildTableFilterQuery(filterText, null, query);
+            query = buildTableFilterQuery(filterText, query);
         }
         Request sampleCountRequest = new Request("GET", SAMPLES_COUNT_END_POINT);
         sampleCountRequest.setJsonEntity(gson.toJson(query));

--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -631,12 +631,6 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         Map<String, Object> query = esService.buildFacetFilterQuery(params, Set.of(), Set.of(PAGE_SIZE, OFFSET, ORDER_BY, SORT_DIRECTION));
         String order_by = (String)params.get(ORDER_BY);
         String direction = ((String)params.get(SORT_DIRECTION)).toLowerCase();
-        // String filterText = (String)params.get(FILTER_TEXT);
-        // if (!filterText.isEmpty() | filterText != null) {
-        //     query = buildTableFilterQuery(filterText, properties, query);
-        // } else {
-        //     query.put("sort", mapSortOrder(order_by, direction, defaultSort, mapping));
-        // }
         query.put("sort", mapSortOrder(order_by, direction, defaultSort, mapping));
         int pageSize = (int) params.get(PAGE_SIZE);
         int offset = (int) params.get(OFFSET);
@@ -660,29 +654,6 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 "lenient", true
             )
         );
-
-        // if (properties != null) {
-        //     // get analyzed versions of props defined in indices yaml
-        //     List<String> fields = Arrays.stream(properties)
-        //     .map(property -> property[1] + ".analyzed")
-        //     .collect(Collectors.toList());
-
-        //     tableMultiMatch = Map.of(
-        //         "multi_match", Map.of(
-        //             "query", filterText,
-        //             "fields", fields,
-        //             "type", "best_fields",
-        //             "lenient", true
-        //         )
-        //     );
-        // } else {
-        //     tableMultiMatch = Map.of(
-        //         "multi_match", Map.of(
-        //             "query", filterText,
-        //             "lenient", true
-        //         )
-        //     );
-        // }
 
         // assemble query
         must.add(tableMultiMatch);

--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -344,7 +344,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         final String subCategory = "study_code";
 
         String[] subCategories = new String[] { subCategory };
-        Map<String, Object> query = esService.buildFacetFilterQuery(params);
+        Map<String, Object> query = esService.buildFacetFilterQuery(params, Set.of(), Set.of(FILTER_TEXT));
         String[] AGG_NAMES = new String[] {category};
         query = esService.addAggregations(query, AGG_NAMES);
         esService.addSubAggregations(query, category, subCategories);

--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -259,7 +259,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         Map<String, Object> query = esService.buildFacetFilterQuery(formattedParams, Set.of(), Set.of("first", SEARCH_TEXT));
         if (!formattedParams.get(SEARCH_TEXT).toString().isEmpty()) {
             String searchText = formattedParams.get(SEARCH_TEXT).toString();
-            query = buildTableFilterQuery(searchText, query);
+            query = buildTableSearchQuery(searchText, query);
         }
         Request sampleCountRequest = new Request("GET", SAMPLES_COUNT_END_POINT);
         sampleCountRequest.setJsonEntity(gson.toJson(query));
@@ -277,7 +277,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         Map<String, Object> studyFileQuery = esService.buildFacetFilterQuery(studyFileParam, Set.of(), Set.of("first", SEARCH_TEXT));
         if (!studyFileParam.get(SEARCH_TEXT).toString().isEmpty()) {
             String studyFileSearchText = formattedParams.get(SEARCH_TEXT).toString();
-            studyFileQuery = buildTableFilterQuery(studyFileSearchText, studyFileQuery);
+            studyFileQuery = buildTableSearchQuery(studyFileSearchText, studyFileQuery);
         }
         studyFileCountRequest.setJsonEntity(gson.toJson(studyFileQuery));
         JsonObject studyFileCountResult = esService.send(studyFileCountRequest);
@@ -638,8 +638,8 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         return page;
     }
 
-    private Map<String, Object> buildTableFilterQuery(String filterText, Map<String, Object> query) {
-        if (filterText == null || filterText.isEmpty()) return Map.of();
+    private Map<String, Object> buildTableSearchQuery(String searchText, Map<String, Object> query) {
+        if (searchText == null || searchText.isEmpty()) return Map.of();
 
         // check if query already contains bool object
         Map<String, Object> boolQuery = (Map<String, Object>) query.getOrDefault("query", Map.of("bool", Map.of()));
@@ -650,7 +650,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
 
         Map<String, Object> tableMultiMatch = Map.of(
             "multi_match", Map.of(
-                "query", filterText,
+                "query", searchText,
                 "lenient", true
             )
         );

--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -266,28 +266,34 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         JsonObject sampleCountResult = esService.send(sampleCountRequest);
         int numberOfSamples = sampleCountResult.get("count").getAsInt();
 
-        Request sampleIdsRequest = new Request("GET", SAMPLES_END_POINT);
-        sampleIdsRequest.setJsonEntity(gson.toJson(query));
-        JsonObject sampleIdsResult = esService.send(sampleIdsRequest);
-        JsonArray sampleIdsArray = sampleIdsResult.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
-        List<String> sampleIds = new ArrayList<>();
-        for (var sampleId: sampleIdsArray) {
-            sampleIds.add(sampleId.getAsJsonObject().get("_source").getAsJsonObject().get("sample_ids").getAsString());
-        }
+        // Request sampleIdsRequest = new Request("GET", SAMPLES_END_POINT);
+        // sampleIdsRequest.setJsonEntity(gson.toJson(query));
+        // JsonObject sampleIdsResult = esService.send(sampleIdsRequest);
+        // JsonArray sampleIdsArray = sampleIdsResult.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
+        // List<String> sampleIds = new ArrayList<>();
+        // for (var sampleId: sampleIdsArray) {
+        //     sampleIds.add(sampleId.getAsJsonObject().get("_source").getAsJsonObject().get("sample_ids").getAsString());
+        // }
+
+        List<String> sampleIds = fetchIdsFromResults(query, SAMPLES_END_POINT, "sample_ids");
+        System.out.println("SAMPLE IDS: " + sampleIds);
 
         Request fileCountRequest = new Request("GET", FILES_COUNT_END_POINT);
         fileCountRequest.setJsonEntity(gson.toJson(query));
         JsonObject fileCountResult = esService.send(fileCountRequest);
         int numberOfFiles = fileCountResult.get("count").getAsInt();
 
-        Request fileIdsRequest = new Request("GET", FILES_END_POINT);
-        fileIdsRequest.setJsonEntity(gson.toJson(query));
-        JsonObject fileIdsResult = esService.send(fileIdsRequest);
-        JsonArray fileIdsArray = fileIdsResult.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
-        List<String> fileIds = new ArrayList<>();
-        for (var fileId: fileIdsArray) {
-            fileIds.add(fileId.getAsJsonObject().get("_source").getAsJsonObject().get("file_uuids").getAsString());
-        }
+        // Request fileIdsRequest = new Request("GET", FILES_END_POINT);
+        // fileIdsRequest.setJsonEntity(gson.toJson(query));
+        // JsonObject fileIdsResult = esService.send(fileIdsRequest);
+        // JsonArray fileIdsArray = fileIdsResult.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
+        // List<String> fileIds = new ArrayList<>();
+        // for (var fileId: fileIdsArray) {
+        //     fileIds.add(fileId.getAsJsonObject().get("_source").getAsJsonObject().get("file_uuids").getAsString());
+        // }
+
+        List<String> fileIds = fetchIdsFromResults(query, FILES_END_POINT, "file_uuids");
+        System.out.println("FILE IDS:  " + fileIds);
 
         Request studyFileCountRequest = new Request("GET", FILES_COUNT_END_POINT);
         Map<String, Object> studyFileParam = new HashMap<>(formattedParams);
@@ -297,28 +303,34 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         JsonObject studyFileCountResult = esService.send(studyFileCountRequest);
         int numberOfStudyFiles = studyFileCountResult.get("count").getAsInt();
 
-        Request studyFileIdsRequest = new Request("GET", FILES_END_POINT);
-        studyFileIdsRequest.setJsonEntity(gson.toJson(studyFileQuery));
-        JsonObject studyFileIdsResult = esService.send(studyFileIdsRequest);
-        JsonArray studyFileIdsArray = studyFileIdsResult.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
-        List<String> studyFileIds = new ArrayList<>();
-        for (var studyFileId: studyFileIdsArray) {
-            studyFileIds.add(studyFileId.getAsJsonObject().get("_source").getAsJsonObject().get("file_uuids").getAsString());
-        }
+        // Request studyFileIdsRequest = new Request("GET", FILES_END_POINT);
+        // studyFileIdsRequest.setJsonEntity(gson.toJson(studyFileQuery));
+        // JsonObject studyFileIdsResult = esService.send(studyFileIdsRequest);
+        // JsonArray studyFileIdsArray = studyFileIdsResult.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
+        // List<String> studyFileIds = new ArrayList<>();
+        // for (var studyFileId: studyFileIdsArray) {
+        //     studyFileIds.add(studyFileId.getAsJsonObject().get("_source").getAsJsonObject().get("file_uuids").getAsString());
+        // }
+
+        List<String> studyFileIds = fetchIdsFromResults(studyFileQuery, FILES_END_POINT, "file_uuids");
+        System.out.println("STUDY FILE IDS:  " + fileIds);
 
         Request caseCountRequest = new Request("GET", CASES_COUNT_END_POINT);
         caseCountRequest.setJsonEntity(gson.toJson(query));
         JsonObject caseCountResult = esService.send(caseCountRequest);
         int numberOfCases = caseCountResult.get("count").getAsInt();
 
-        Request caseIdsRequest = new Request("GET", CASES_END_POINT);
-        caseIdsRequest.setJsonEntity(gson.toJson(query));
-        JsonObject caseIdsResult = esService.send(caseIdsRequest);
-        JsonArray caseIdsArray = caseIdsResult.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
-        List<String> caseIds = new ArrayList<>();
-        for (var caseId: caseIdsArray) {
-            caseIds.add(caseId.getAsJsonObject().get("_source").getAsJsonObject().get("case_ids").getAsString());
-        }
+        // Request caseIdsRequest = new Request("GET", CASES_END_POINT);
+        // caseIdsRequest.setJsonEntity(gson.toJson(query));
+        // JsonObject caseIdsResult = esService.send(caseIdsRequest);
+        // JsonArray caseIdsArray = caseIdsResult.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
+        // List<String> caseIds = new ArrayList<>();
+        // for (var caseId: caseIdsArray) {
+        //     caseIds.add(caseId.getAsJsonObject().get("_source").getAsJsonObject().get("case_ids").getAsString());
+        // }
+
+        List<String> caseIds = fetchIdsFromResults(query, CASES_END_POINT, "case_ids");
+        System.out.println("CASE IDS:  " + caseIds);
 
         // Get aggregations
         Map<String, Object> aggQuery = esService.addAggregations(query, TERM_AGG_NAMES);
@@ -368,6 +380,18 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         }
 
         return data;
+    }
+
+    private List<String> fetchIdsFromResults(Map<String, Object> query, String endpoint, String idField) throws IOException {
+        Request request = new Request("GET", endpoint);
+        request.setJsonEntity(gson.toJson(query));
+        JsonObject result = esService.send(request);
+        JsonArray hitsArray = result.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
+        List<String> idsArray = new ArrayList<>();
+        for (var id: hitsArray) {
+            idsArray.add(id.getAsJsonObject().get("_source").getAsJsonObject().get(idField).getAsString());
+        }
+        return idsArray;
     }
 
     private double getVolumeOfData(Map<String, Object> params, String fieldName, String indexName) throws IOException {

--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -293,6 +293,10 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         Map<String, Object> studyFileParam = new HashMap<>(formattedParams);
         studyFileParam.put("file_level", List.of("study"));
         Map<String, Object> studyFileQuery = esService.buildFacetFilterQuery(studyFileParam, Set.of(), Set.of("first", SEARCH_TEXT));
+        if (!studyFileParam.get(SEARCH_TEXT).toString().isEmpty()) {
+            String studyFileSearchText = formattedParams.get(SEARCH_TEXT).toString();
+            studyFileQuery = buildTableFilterQuery(studyFileSearchText, studyFileQuery);
+        }
         studyFileCountRequest.setJsonEntity(gson.toJson(studyFileQuery));
         JsonObject studyFileCountResult = esService.send(studyFileCountRequest);
         int numberOfStudyFiles = studyFileCountResult.get("count").getAsInt();

--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -657,7 +657,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         return page;
     }
 
-    private Map<String, Object> buildTableFilterQuery(String filterText, String[][] properties, Map<String, Object> query) {
+    private Map<String, Object> buildTableFilterQuery(String filterText, Map<String, Object> query) {
         if (filterText == null || filterText.isEmpty()) return Map.of();
 
         // check if query already contains bool object
@@ -667,30 +667,35 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         List<Object> must = new ArrayList<>((List<Object>) ((Map<String, Object>) boolQuery.getOrDefault("bool", Map.of())).getOrDefault("must", List.of()));
         List<Object> filter = new ArrayList<>((List<Object>) ((Map<String, Object>) boolQuery.getOrDefault("bool", Map.of())).getOrDefault("filter", List.of()));
 
-        Map<String, Object> tableMultiMatch;
+        Map<String, Object> tableMultiMatch = Map.of(
+            "multi_match", Map.of(
+                "query", filterText,
+                "lenient", true
+            )
+        );
 
-        if (properties != null) {
-            // get analyzed versions of props defined in indices yaml
-            List<String> fields = Arrays.stream(properties)
-            .map(property -> property[1] + ".analyzed")
-            .collect(Collectors.toList());
+        // if (properties != null) {
+        //     // get analyzed versions of props defined in indices yaml
+        //     List<String> fields = Arrays.stream(properties)
+        //     .map(property -> property[1] + ".analyzed")
+        //     .collect(Collectors.toList());
 
-            tableMultiMatch = Map.of(
-                "multi_match", Map.of(
-                    "query", filterText,
-                    "fields", fields,
-                    "type", "best_fields",
-                    "lenient", true
-                )
-            );
-        } else {
-            tableMultiMatch = Map.of(
-                "multi_match", Map.of(
-                    "query", filterText,
-                    "lenient", true
-                )
-            );
-        }
+        //     tableMultiMatch = Map.of(
+        //         "multi_match", Map.of(
+        //             "query", filterText,
+        //             "fields", fields,
+        //             "type", "best_fields",
+        //             "lenient", true
+        //         )
+        //     );
+        // } else {
+        //     tableMultiMatch = Map.of(
+        //         "multi_match", Map.of(
+        //             "query", filterText,
+        //             "lenient", true
+        //         )
+        //     );
+        // }
 
         // assemble query
         must.add(tableMultiMatch);

--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -274,7 +274,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         Request studyFileCountRequest = new Request("GET", FILES_COUNT_END_POINT);
         Map<String, Object> studyFileParam = new HashMap<>(formattedParams);
         studyFileParam.put("file_level", List.of("study"));
-        Map<String, Object> studyFileQuery = esService.buildFacetFilterQuery(studyFileParam, Set.of(), Set.of("first"));
+        Map<String, Object> studyFileQuery = esService.buildFacetFilterQuery(studyFileParam, Set.of(), Set.of("first", FILTER_TEXT));
         studyFileCountRequest.setJsonEntity(gson.toJson(studyFileQuery));
         JsonObject studyFileCountResult = esService.send(studyFileCountRequest);
         int numberOfStudyFiles = studyFileCountResult.get("count").getAsInt();
@@ -331,7 +331,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
     }
 
     private double getVolumeOfData(Map<String, Object> params, String fieldName, String indexName) throws IOException {
-        Map<String, Object> query = esService.buildFacetFilterQuery(params);
+        Map<String, Object> query = esService.buildFacetFilterQuery(params, Set.of(), Set.of(FILTER_TEXT));
         query = esService.addSumAggregation(query, fieldName);
         Request request = new Request("GET", indexName);
         request.setJsonEntity(gson.toJson(query));
@@ -375,12 +375,12 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
     }
 
     private List<Map<String, Object>> subjectCountBy(String category, Map<String, Object> params, String endpoint) throws IOException {
-        Map<String, Object> query = esService.buildFacetFilterQuery(params, RANGE_PARAMS, Set.of(PAGE_SIZE));
+        Map<String, Object> query = esService.buildFacetFilterQuery(params, RANGE_PARAMS, Set.of(PAGE_SIZE, FILTER_TEXT));
         return getGroupCount(category, query, endpoint);
     }
 
     private List<Map<String, Object>> filterSubjectCountBy(String category, Map<String, Object> params, String endpoint) throws IOException {
-        Map<String, Object> query = esService.buildFacetFilterQuery(params, RANGE_PARAMS, Set.of(PAGE_SIZE, category));
+        Map<String, Object> query = esService.buildFacetFilterQuery(params, RANGE_PARAMS, Set.of(PAGE_SIZE, category, FILTER_TEXT));
         return getGroupCount(category, query, endpoint);
     }
 

--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -266,28 +266,10 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         JsonObject sampleCountResult = esService.send(sampleCountRequest);
         int numberOfSamples = sampleCountResult.get("count").getAsInt();
 
-        // Request sampleIdsRequest = new Request("GET", SAMPLES_END_POINT);
-        // sampleIdsRequest.setJsonEntity(gson.toJson(query));
-        // JsonObject sampleIdsResult = esService.send(sampleIdsRequest);
-        // JsonArray sampleIdsArray = sampleIdsResult.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
-        // List<String> sampleIds = new ArrayList<>();
-        // for (var sampleId: sampleIdsArray) {
-        //     sampleIds.add(sampleId.getAsJsonObject().get("_source").getAsJsonObject().get("sample_ids").getAsString());
-        // }
-
         Request fileCountRequest = new Request("GET", FILES_COUNT_END_POINT);
         fileCountRequest.setJsonEntity(gson.toJson(query));
         JsonObject fileCountResult = esService.send(fileCountRequest);
         int numberOfFiles = fileCountResult.get("count").getAsInt();
-
-        // Request fileIdsRequest = new Request("GET", FILES_END_POINT);
-        // fileIdsRequest.setJsonEntity(gson.toJson(query));
-        // JsonObject fileIdsResult = esService.send(fileIdsRequest);
-        // JsonArray fileIdsArray = fileIdsResult.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
-        // List<String> fileIds = new ArrayList<>();
-        // for (var fileId: fileIdsArray) {
-        //     fileIds.add(fileId.getAsJsonObject().get("_source").getAsJsonObject().get("file_uuids").getAsString());
-        // }
 
         Request studyFileCountRequest = new Request("GET", FILES_COUNT_END_POINT);
         Map<String, Object> studyFileParam = new HashMap<>(formattedParams);
@@ -301,28 +283,10 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         JsonObject studyFileCountResult = esService.send(studyFileCountRequest);
         int numberOfStudyFiles = studyFileCountResult.get("count").getAsInt();
 
-        // Request studyFileIdsRequest = new Request("GET", FILES_END_POINT);
-        // studyFileIdsRequest.setJsonEntity(gson.toJson(studyFileQuery));
-        // JsonObject studyFileIdsResult = esService.send(studyFileIdsRequest);
-        // JsonArray studyFileIdsArray = studyFileIdsResult.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
-        // List<String> studyFileIds = new ArrayList<>();
-        // for (var studyFileId: studyFileIdsArray) {
-        //     studyFileIds.add(studyFileId.getAsJsonObject().get("_source").getAsJsonObject().get("file_uuids").getAsString());
-        // }
-
         Request caseCountRequest = new Request("GET", CASES_COUNT_END_POINT);
         caseCountRequest.setJsonEntity(gson.toJson(query));
         JsonObject caseCountResult = esService.send(caseCountRequest);
         int numberOfCases = caseCountResult.get("count").getAsInt();
-
-        // Request caseIdsRequest = new Request("GET", CASES_END_POINT);
-        // caseIdsRequest.setJsonEntity(gson.toJson(query));
-        // JsonObject caseIdsResult = esService.send(caseIdsRequest);
-        // JsonArray caseIdsArray = caseIdsResult.get("hits").getAsJsonObject().get("hits").getAsJsonArray();
-        // List<String> caseIds = new ArrayList<>();
-        // for (var caseId: caseIdsArray) {
-        //     caseIds.add(caseId.getAsJsonObject().get("_source").getAsJsonObject().get("case_ids").getAsString());
-        // }
 
         // get IDs associated with corresponding counts
         List<String> caseIds = fetchIdsFromResults(query, CASES_END_POINT, "case_ids", numberOfCases);

--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -33,7 +33,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
     final String OFFSET = "offset";
     final String ORDER_BY = "order_by";
     final String SORT_DIRECTION = "sort_direction";
-    final String FILTER_TEXT = "filter_text";
+    final String SEARCH_TEXT = "search_text";
 
     final String PROGRAMS_END_POINT = "/programs/_search";
     final String PROGRAMS_COUNT_END_POINT = "/programs/_count";
@@ -256,10 +256,10 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         }
         final String[] TERM_AGG_NAMES = agg_names.toArray(new String[TERM_AGGS.size()]);
 
-        Map<String, Object> query = esService.buildFacetFilterQuery(formattedParams, Set.of(), Set.of("first", FILTER_TEXT));
-        if (!formattedParams.get(FILTER_TEXT).toString().isEmpty()) {
-            String filterText = formattedParams.get(FILTER_TEXT).toString();
-            query = buildTableFilterQuery(filterText, query);
+        Map<String, Object> query = esService.buildFacetFilterQuery(formattedParams, Set.of(), Set.of("first", SEARCH_TEXT));
+        if (!formattedParams.get(SEARCH_TEXT).toString().isEmpty()) {
+            String searchText = formattedParams.get(SEARCH_TEXT).toString();
+            query = buildTableFilterQuery(searchText, query);
         }
         Request sampleCountRequest = new Request("GET", SAMPLES_COUNT_END_POINT);
         sampleCountRequest.setJsonEntity(gson.toJson(query));
@@ -298,7 +298,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         Request studyFileCountRequest = new Request("GET", FILES_COUNT_END_POINT);
         Map<String, Object> studyFileParam = new HashMap<>(formattedParams);
         studyFileParam.put("file_level", List.of("study"));
-        Map<String, Object> studyFileQuery = esService.buildFacetFilterQuery(studyFileParam, Set.of(), Set.of("first", FILTER_TEXT));
+        Map<String, Object> studyFileQuery = esService.buildFacetFilterQuery(studyFileParam, Set.of(), Set.of("first", SEARCH_TEXT));
         studyFileCountRequest.setJsonEntity(gson.toJson(studyFileQuery));
         JsonObject studyFileCountResult = esService.send(studyFileCountRequest);
         int numberOfStudyFiles = studyFileCountResult.get("count").getAsInt();
@@ -395,7 +395,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
     }
 
     private double getVolumeOfData(Map<String, Object> params, String fieldName, String indexName) throws IOException {
-        Map<String, Object> query = esService.buildFacetFilterQuery(params, Set.of(), Set.of(FILTER_TEXT));
+        Map<String, Object> query = esService.buildFacetFilterQuery(params, Set.of(), Set.of(SEARCH_TEXT));
         query = esService.addSumAggregation(query, fieldName);
         Request request = new Request("GET", indexName);
         request.setJsonEntity(gson.toJson(query));
@@ -408,7 +408,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         final String subCategory = "study_code";
 
         String[] subCategories = new String[] { subCategory };
-        Map<String, Object> query = esService.buildFacetFilterQuery(params, Set.of(), Set.of(FILTER_TEXT));
+        Map<String, Object> query = esService.buildFacetFilterQuery(params, Set.of(), Set.of(SEARCH_TEXT));
         String[] AGG_NAMES = new String[] {category};
         query = esService.addAggregations(query, AGG_NAMES);
         esService.addSubAggregations(query, category, subCategories);
@@ -439,12 +439,12 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
     }
 
     private List<Map<String, Object>> subjectCountBy(String category, Map<String, Object> params, String endpoint) throws IOException {
-        Map<String, Object> query = esService.buildFacetFilterQuery(params, RANGE_PARAMS, Set.of(PAGE_SIZE, FILTER_TEXT));
+        Map<String, Object> query = esService.buildFacetFilterQuery(params, RANGE_PARAMS, Set.of(PAGE_SIZE, SEARCH_TEXT));
         return getGroupCount(category, query, endpoint);
     }
 
     private List<Map<String, Object>> filterSubjectCountBy(String category, Map<String, Object> params, String endpoint) throws IOException {
-        Map<String, Object> query = esService.buildFacetFilterQuery(params, RANGE_PARAMS, Set.of(PAGE_SIZE, category, FILTER_TEXT));
+        Map<String, Object> query = esService.buildFacetFilterQuery(params, RANGE_PARAMS, Set.of(PAGE_SIZE, category, SEARCH_TEXT));
         return getGroupCount(category, query, endpoint);
     }
 

--- a/src/main/resources/graphql/icdc-es.graphql
+++ b/src/main/resources/graphql/icdc-es.graphql
@@ -322,6 +322,7 @@ type QueryType {
     file_association: [String] = []
     file_type: [String] = []
     file_format: [String] = []
+    filter_text: String = ""
   ): SearchResult
 
   caseOverview(

--- a/src/main/resources/graphql/icdc-es.graphql
+++ b/src/main/resources/graphql/icdc-es.graphql
@@ -380,6 +380,7 @@ type QueryType {
     sort_direction: String = "ASC"
     first: Int = 10
     offset: Int = 0
+    filter_text: String
   ): [SampleOverviewES]
 
   fileOverview(
@@ -411,6 +412,7 @@ type QueryType {
     sort_direction: String = "ASC"
     first: Int = 10
     offset: Int = 0
+    filter_text: String
   ): [FileOverviewES]
 
   globalSearch(

--- a/src/main/resources/graphql/icdc-es.graphql
+++ b/src/main/resources/graphql/icdc-es.graphql
@@ -170,6 +170,10 @@ type SearchResult {
   numberOfStudyFiles: Int
   numberOfAliquots: Int
   volumeOfData: Float
+  caseIds: [String]
+  sampleIds: [String]
+  fileIds: [String]
+  studyFileIds: [String]
 
   caseCountByProgram: [GroupCountES]
   caseCountByStudyCode: [GroupCountES]

--- a/src/main/resources/graphql/icdc-es.graphql
+++ b/src/main/resources/graphql/icdc-es.graphql
@@ -350,6 +350,7 @@ type QueryType {
     sort_direction: String = "ASC"
     first: Int = 10
     offset: Int = 0
+    filter_text: String
   ): [CaseOverviewES]
 
   sampleOverview(

--- a/src/main/resources/graphql/icdc-es.graphql
+++ b/src/main/resources/graphql/icdc-es.graphql
@@ -350,7 +350,7 @@ type QueryType {
     sort_direction: String = "ASC"
     first: Int = 10
     offset: Int = 0
-    filter_text: String
+    filter_text: String = ""
   ): [CaseOverviewES]
 
   sampleOverview(
@@ -380,7 +380,7 @@ type QueryType {
     sort_direction: String = "ASC"
     first: Int = 10
     offset: Int = 0
-    filter_text: String
+    filter_text: String = ""
   ): [SampleOverviewES]
 
   fileOverview(
@@ -412,7 +412,7 @@ type QueryType {
     sort_direction: String = "ASC"
     first: Int = 10
     offset: Int = 0
-    filter_text: String
+    filter_text: String = ""
   ): [FileOverviewES]
 
   globalSearch(

--- a/src/main/resources/graphql/icdc-es.graphql
+++ b/src/main/resources/graphql/icdc-es.graphql
@@ -355,7 +355,6 @@ type QueryType {
     sort_direction: String = "ASC"
     first: Int = 10
     offset: Int = 0
-    filter_text: String = ""
   ): [CaseOverviewES]
 
   sampleOverview(
@@ -385,7 +384,6 @@ type QueryType {
     sort_direction: String = "ASC"
     first: Int = 10
     offset: Int = 0
-    filter_text: String = ""
   ): [SampleOverviewES]
 
   fileOverview(
@@ -417,7 +415,6 @@ type QueryType {
     sort_direction: String = "ASC"
     first: Int = 10
     offset: Int = 0
-    filter_text: String = ""
   ): [FileOverviewES]
 
   globalSearch(

--- a/src/main/resources/graphql/icdc-es.graphql
+++ b/src/main/resources/graphql/icdc-es.graphql
@@ -326,7 +326,7 @@ type QueryType {
     file_association: [String] = []
     file_type: [String] = []
     file_format: [String] = []
-    filter_text: String = ""
+    search_text: String = ""
   ): SearchResult
 
   caseOverview(

--- a/src/main/resources/yaml/es_indices_icdc.yml
+++ b/src/main/resources/yaml/es_indices_icdc.yml
@@ -11,26 +11,47 @@ Indices:
         type: keyword
       study_type:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       biobank:
         type: keyword
       study_participation:
         type: keyword
       breed:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       breed_txt:
         type: text
       diagnosis:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       disease_site:
         type: keyword
       stage_of_disease:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       response_to_treatment:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       sex:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       neutered_status:
         type: keyword
+        fields:
+          analyzed:
+            type: text
 
       sample_type:
         type: keyword
@@ -52,6 +73,9 @@ Indices:
         type: text
       case_id_kw:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
       case_id_lc:
         type: keyword
 
@@ -63,12 +87,25 @@ Indices:
         type: text
       study_code:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
       cohort:
         type: keyword
+        fields:
+          analyzed:
+            type: text
+
       age:
         type: float
+        fields:
+          analyzed:
+            type: text
       weight:
         type: float
+        fields:
+          analyzed:
+            type: text
       files:
         type: keyword
       other_cases:

--- a/src/main/resources/yaml/es_indices_icdc.yml
+++ b/src/main/resources/yaml/es_indices_icdc.yml
@@ -221,8 +221,14 @@ Indices:
         type: keyword
       breed:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       diagnosis:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
       disease_site:
         type: keyword
       stage_of_disease:
@@ -236,8 +242,14 @@ Indices:
 
       sample_type:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       sample_pathology:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
 
       file_association:
         type: keyword
@@ -248,12 +260,18 @@ Indices:
 
       case_ids:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
       case_ids_txt:
         type: text
       case_id_lc:
         type: keyword
       sample_ids:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
       sample_ids_txt:
         type: text
 
@@ -263,6 +281,9 @@ Indices:
         type: text
       sample_site:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       sample_site_txt:
         type: text
       physical_sample_type:
@@ -275,14 +296,29 @@ Indices:
         type: text
       tumor_grade:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       sample_chronology:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       percentage_tumor:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       necropsy_sample:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       sample_preservation:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       tumor_sample_origin:
         type: keyword
       comment:
@@ -428,6 +464,9 @@ Indices:
         type: keyword
       diagnosis:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
       disease_site:
         type: keyword
       response_to_treatment:
@@ -442,6 +481,9 @@ Indices:
 
       file_association:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
       file_type_txt:
         type: text
       file_level:
@@ -449,6 +491,9 @@ Indices:
 
       case_ids:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
       case_ids_txt:
         type: text
       case_id_lc:
@@ -468,6 +513,9 @@ Indices:
         type: text
       study_code:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
       individual_id:
         type: keyword
       arm:
@@ -501,6 +549,9 @@ Indices:
         type: keyword
       breed:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       additional_breed_detail:
         type: keyword
       patient_age_at_enrollment:
@@ -525,6 +576,9 @@ Indices:
       # SAMPLE
       sample_id:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
       sample_site:
         type: keyword
       physical_sample_type:
@@ -593,14 +647,29 @@ Indices:
       # FILE
       file_name:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
       file_type:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       file_description:
         type: keyword
+        fields:
+          analyzed:
+            type: text
       file_format:
         type: keyword
+        fields:
+          analyzed:
+            type: keyword
       file_size:
         type: double
+        fields:
+          analyzed:
+            type: text
       md5sum:
         type: keyword
       file_status:

--- a/src/main/resources/yaml/es_indices_icdc.yml
+++ b/src/main/resources/yaml/es_indices_icdc.yml
@@ -228,7 +228,7 @@ Indices:
         type: keyword
         fields:
           analyzed:
-            type: keyword
+            type: text
       disease_site:
         type: keyword
       stage_of_disease:
@@ -249,7 +249,7 @@ Indices:
         type: keyword
         fields:
           analyzed:
-            type: keyword
+            type: text
 
       file_association:
         type: keyword
@@ -262,7 +262,7 @@ Indices:
         type: keyword
         fields:
           analyzed:
-            type: keyword
+            type: text
       case_ids_txt:
         type: text
       case_id_lc:
@@ -271,7 +271,7 @@ Indices:
         type: keyword
         fields:
           analyzed:
-            type: keyword
+            type: text
       sample_ids_txt:
         type: text
 
@@ -466,7 +466,7 @@ Indices:
         type: keyword
         fields:
           analyzed:
-            type: keyword
+            type: text
       disease_site:
         type: keyword
       response_to_treatment:
@@ -483,7 +483,7 @@ Indices:
         type: keyword
         fields:
           analyzed:
-            type: keyword
+            type: text
       file_type_txt:
         type: text
       file_level:
@@ -493,7 +493,7 @@ Indices:
         type: keyword
         fields:
           analyzed:
-            type: keyword
+            type: text
       case_ids_txt:
         type: text
       case_id_lc:
@@ -515,7 +515,7 @@ Indices:
         type: keyword
         fields:
           analyzed:
-            type: keyword
+            type: text
       individual_id:
         type: keyword
       arm:
@@ -578,7 +578,7 @@ Indices:
         type: keyword
         fields:
           analyzed:
-            type: keyword
+            type: text
       sample_site:
         type: keyword
       physical_sample_type:
@@ -649,7 +649,7 @@ Indices:
         type: keyword
         fields:
           analyzed:
-            type: keyword
+            type: text
       file_type:
         type: keyword
         fields:
@@ -664,7 +664,7 @@ Indices:
         type: keyword
         fields:
           analyzed:
-            type: keyword
+            type: text
       file_size:
         type: double
         fields:


### PR DESCRIPTION
- update `searchCases` query to accept `search_text` param and, if present and a non-empty string, return case/sample/file IDs that are associated with data containing/matching the `search_text` value (further filtering will occur in case/sample/file overview queries)