### PR TITLE
revert schema changes introduced via model converter script using dev branch of model tool

### DIFF
--- a/src/main/resources/graphql/icdc-doc.graphql
+++ b/src/main/resources/graphql/icdc-doc.graphql
@@ -18,7 +18,6 @@ type adverse_event {
   other_attribution_description: String
   dose_limiting_toxicity: String
   unexpected_adverse_event: String
-  crdc_id: String
   case: case 
   agent: agent 
   cases: [case] 
@@ -29,7 +28,6 @@ type adverse_event {
 type agent {
   medication: String
   document_number: String
-  crdc_id: String
   study_arms: [study_arm] 
   agent_administrations: [agent_administration] 
   adverse_events: [adverse_event] 
@@ -68,7 +66,6 @@ type agent_administration {
   missed_dose_units_of_measure: String
   medication_course_number: String
   comment: String
-  crdc_id: String
   agent: agent 
   visit: visit 
 }
@@ -82,12 +79,10 @@ type assay {
 type biospecimen_source {
   biospecimen_repository_acronym: String
   biospecimen_repository_full_name: String
-  crdc_id: String
 }
 
 type canine_individual {
   canine_individual_id: String
-  crdc_id: String
   cases: [case] 
 }
 
@@ -95,12 +90,11 @@ type case {
   case_id: String
   patient_id: String
   patient_first_name: String
-  crdc_id: String
   cohort: cohort 
   study: study 
   enrollment: enrollment 
   demographic: demographic 
-  diagnosis: diagnosis 
+  diagnoses: [diagnosis] 
   cycles: [cycle] 
   follow_ups: [follow_up] 
   samples: [sample] 
@@ -117,9 +111,8 @@ type case {
 
 type cohort {
   cohort_description: String
-  cohort_id: String
   cohort_dose: String
-  crdc_id: String
+  cohort_id: String
   cases: [case] 
   study_arm: study_arm 
   study: study 
@@ -129,7 +122,6 @@ type cycle {
   cycle_number: Int
   date_of_cycle_start: String
   date_of_cycle_end: String
-  crdc_id: String
   case: case 
   visits: [visit] 
 }
@@ -149,7 +141,6 @@ type demographic {
   weight_original: Float
   weight_original_unit: String
   neutered_indicator: String
-  crdc_id: String
   case: case 
 }
 
@@ -168,13 +159,12 @@ type diagnosis {
   follow_up_data: String
   concurrent_disease: String
   concurrent_disease_type: String
-  crdc_id: String
   case: case 
   files: [file] 
 }
 
 type disease_extent {
-  lesion_number: Int
+  lesion_number: String
   lesion_site: String
   lesion_description: String
   previously_irradiated: String
@@ -187,9 +177,8 @@ type disease_extent {
   longest_measurement_unit: String
   longest_measurement_original: Float
   longest_measurement_original_unit: String
-  evaluation_number: Int
+  evaluation_number: String
   evaluation_code: String
-  crdc_id: String
   visit: visit 
 }
 
@@ -202,7 +191,6 @@ type enrollment {
   site_short_name: String
   veterinary_medical_center: String
   patient_subgroup: String
-  crdc_id: String
   case: case 
   prior_therapies: [prior_therapy] 
   prior_surgeries: [prior_surgery] 
@@ -214,12 +202,11 @@ type file {
   file_type: String
   file_description: String
   file_format: String
-  file_size: Int
+  file_size: Float
   md5sum: String
   file_status: String
   uuid: String
   file_location: String
-  crdc_id: String
   case: case 
   study: study 
   sample: sample 
@@ -236,19 +223,7 @@ type follow_up {
   treatment_since_last_contact: Boolean
   physical_exam_performed: Boolean
   physical_exam_changes: String
-  crdc_id: String
   case: case 
-}
-
-type human_relevance {
-  human_relevance_record_id: String
-  human_relevance_statement: String
-  relevant_human_cancer: String
-  relevant_experimental_therapeutic_intervention: String
-  relevant_human_genes: String
-  relevant_human_pathways: String
-  nci_link_to_relevant_human_cancer: String
-  study: study 
 }
 
 type image {
@@ -261,7 +236,6 @@ type image_collection {
   image_collection_url: String
   repository_name: String
   collection_access: String
-  crdc_id: String
   study: study 
 }
 
@@ -279,7 +253,6 @@ type off_study {
   date_last_medication_administration: String
   best_resp_vet_tx_tp_best_response: String
   date_of_best_response: String
-  crdc_id: String
   case: case 
 }
 
@@ -292,7 +265,6 @@ type off_treatment {
   date_last_medication_administration: String
   best_resp_vet_tx_tp_best_response: String
   date_of_best_response: String
-  crdc_id: String
   case: case 
 }
 
@@ -303,8 +275,7 @@ type physical_exam {
   pe_finding: String
   pe_comment: String
   phase_pe: String
-  assessment_timepoint: String
-  crdc_id: String
+  assessment_timepoint: Int
   enrollment: enrollment 
   visit: visit 
 }
@@ -313,7 +284,6 @@ type principal_investigator {
   pi_first_name: String
   pi_last_name: String
   pi_middle_initial: String
-  crdc_id: String
   studies: [study] 
 }
 
@@ -324,7 +294,6 @@ type prior_surgery {
   surgical_finding: String
   residual_disease: String
   therapeutic_indicator: String
-  crdc_id: String
   enrollment: enrollment 
   next_prior_surgery: prior_surgery 
   prior_prior_surgery: prior_surgery 
@@ -360,7 +329,6 @@ type prior_therapy {
   date_of_last_dose_any_therapy: String
   treatment_performed_at_site: Boolean
   treatment_performed_in_minimal_residual: Boolean
-  crdc_id: String
   enrollment: enrollment 
   next_prior_therapy: prior_therapy 
   prior_prior_therapy: prior_therapy 
@@ -373,7 +341,6 @@ type program {
   program_full_description: String
   program_external_url: String
   program_sort_order: Int
-  crdc_id: String
   studies: [study] 
 }
 
@@ -384,14 +351,12 @@ type publication {
   journal_citation: String
   digital_object_id: String
   pubmed_id: Float
-  crdc_id: String
   study: study 
 }
 
 type registration {
   registration_origin: String
   registration_id: String
-  crdc_id: String
   cases: [case] 
 }
 
@@ -423,7 +388,6 @@ type sample {
   percentage_tumor: String
   sample_preservation: String
   comment: String
-  crdc_id: String
   case: case 
   visit: visit 
   assays: [assay] 
@@ -442,12 +406,10 @@ type study {
   dates_of_conduct: String
   accession_id: String
   study_disposition: String
-  crdc_id: String
   study_arms: [study_arm] 
   program: program 
   cases: [case] 
   cohorts: [cohort] 
-  human_relevance: human_relevance 
   study_sites: [study_site] 
   principal_investigators: [principal_investigator] 
   files: [file] 
@@ -457,10 +419,9 @@ type study {
 
 type study_arm {
   arm: String
+  ctep_treatment_assignment_code: String
   arm_description: String
   arm_id: String
-  ctep_treatment_assignment_code: String
-  crdc_id: String
   cohorts: [cohort] 
   study: study 
   agents: [agent] 
@@ -471,15 +432,13 @@ type study_site {
   site_short_name: String
   veterinary_medical_center: String
   registering_institution: String
-  crdc_id: String
   studies: [study] 
 }
 
 type visit {
   visit_date: String
-  visit_number: Int
+  visit_number: String
   visit_id: String
-  crdc_id: String
   case: case 
   cycle: cycle 
   agent_administrations: [agent_administration] 
@@ -498,24 +457,23 @@ type vital_signs {
   body_temperature_unit: String
   body_temperature_original: Float
   body_temperature_original_unit: String
+  pulse: Int
+  pulse_unit: String
+  pulse_original: Int
+  pulse_original_unit: String
   respiration_rate: Int
   respiration_rate_unit: String
   respiration_rate_original: Int
   respiration_rate_original_unit: String
   respiration_pattern: String
-  pulse: Int
-  pulse_unit: String
-  pulse_original: Int
-  pulse_original_unit: String
-  pulse_ox: Float
-  pulse_ox_unit: String
-  pulse_ox_original: Float
-  pulse_ox_original_unit: String
   systolic_bp: Int
   systolic_bp_unit: String
   systolic_bp_original: Int
   systolic_bp_original_unit: String
-  ecg: String
+  pulse_ox: Float
+  pulse_ox_unit: String
+  pulse_ox_original: Float
+  pulse_ox_original_unit: String
   patient_weight: Float
   patient_weight_unit: String
   patient_weight_original: Float
@@ -525,9 +483,9 @@ type vital_signs {
   body_surface_area_original: Float
   body_surface_area_original_unit: String
   modified_ecog: String
-  assessment_timepoint: String
+  ecg: String
+  assessment_timepoint: Int
   phase: String
-  crdc_id: String
   visit: visit 
 }
 

--- a/src/main/resources/graphql/icdc-doc.graphql
+++ b/src/main/resources/graphql/icdc-doc.graphql
@@ -226,6 +226,17 @@ type follow_up {
   case: case 
 }
 
+type human_relevance {
+  human_relevance_record_id: String
+  human_relevance_statement: String
+  relevant_human_cancer: String
+  relevant_experimental_therapeutic_intervention: String
+  relevant_human_genes: String
+  relevant_human_pathways: String
+  nci_link_to_relevant_human_cancer: String
+  study: study 
+}
+
 type image {
   assay: assay 
 }
@@ -410,6 +421,7 @@ type study {
   program: program 
   cases: [case] 
   cohorts: [cohort] 
+  human_relevance: human_relevance
   study_sites: [study_site] 
   principal_investigators: [principal_investigator] 
   files: [file] 

--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -227,6 +227,17 @@ type follow_up {
   case: case @relation(name:"of_case", direction:OUT)
 }
 
+type human_relevance {
+  human_relevance_record_id: String
+  human_relevance_statement: String
+  relevant_human_cancer: String
+  relevant_experimental_therapeutic_intervention: String
+  relevant_human_genes: String
+  relevant_human_pathways: String
+  nci_link_to_relevant_human_cancer: String
+  study: study @relation(name:"of_study", direction:OUT)
+}
+
 type image {
   assay: assay @relation(name:"of_assay", direction:OUT)
   schema_validation_placeholder: String
@@ -413,6 +424,7 @@ type study {
   program: program @relation(name:"member_of", direction:OUT)
   cases: [case] @relation(name:"member_of", direction:IN)
   cohorts: [cohort] @relation(name:"member_of", direction:IN)
+  human_relevance: human_relevance @relation(name:"of_study", direction:IN)
   study_sites: [study_site] @relation(name:"of_study", direction:IN)
   principal_investigators: [principal_investigator] @relation(name:"of_study", direction:IN)
   files: [file] @relation(name:"of_study", direction:IN)

--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -68,7 +68,6 @@ type agent_administration {
   missed_dose_units_of_measure: String
   medication_course_number: String
   comment: String
-  crdc_id: String
   agent: agent @relation(name:"of_agent", direction:OUT)
   visit: visit @relation(name:"on_visit", direction:OUT)
 }
@@ -82,12 +81,10 @@ type assay {
 type biospecimen_source {
   biospecimen_repository_acronym: String
   biospecimen_repository_full_name: String
-  crdc_id: String
 }
 
 type canine_individual {
   canine_individual_id: String
-  crdc_id: String
   cases: [case] @relation(name:"represents", direction:IN)
 }
 
@@ -95,12 +92,11 @@ type case {
   case_id: String
   patient_id: String
   patient_first_name: String
-  crdc_id: String
   cohort: cohort @relation(name:"member_of", direction:OUT)
   study: study @relation(name:"member_of", direction:OUT)
   enrollment: enrollment @relation(name:"of_case", direction:IN)
   demographic: demographic @relation(name:"of_case", direction:IN)
-  diagnosis: diagnosis @relation(name:"of_case", direction:IN)
+  diagnoses: [diagnosis] @relation(name:"of_case", direction:IN)
   cycles: [cycle] @relation(name:"of_case", direction:IN)
   follow_ups: [follow_up] @relation(name:"of_case", direction:IN)
   samples: [sample] @relation(name:"of_case", direction:IN)
@@ -117,9 +113,8 @@ type case {
 
 type cohort {
   cohort_description: String
-  cohort_id: String
   cohort_dose: String
-  crdc_id: String
+  cohort_id: String
   cases: [case] @relation(name:"member_of", direction:IN)
   study_arm: study_arm @relation(name:"member_of", direction:OUT)
   study: study @relation(name:"member_of", direction:OUT)
@@ -129,7 +124,6 @@ type cycle {
   cycle_number: Int
   date_of_cycle_start: String
   date_of_cycle_end: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
   visits: [visit] @relation(name:"of_cycle", direction:IN)
 }
@@ -149,7 +143,6 @@ type demographic {
   weight_original: Float
   weight_original_unit: String
   neutered_indicator: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
 }
 
@@ -168,13 +161,12 @@ type diagnosis {
   follow_up_data: String
   concurrent_disease: String
   concurrent_disease_type: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
   files: [file] @relation(name:"from_diagnosis", direction:IN)
 }
 
 type disease_extent {
-  lesion_number: Int
+  lesion_number: String
   lesion_site: String
   lesion_description: String
   previously_irradiated: String
@@ -187,9 +179,8 @@ type disease_extent {
   longest_measurement_unit: String
   longest_measurement_original: Float
   longest_measurement_original_unit: String
-  evaluation_number: Int
+  evaluation_number: String
   evaluation_code: String
-  crdc_id: String
   visit: visit @relation(name:"on_visit", direction:OUT)
 }
 
@@ -202,7 +193,6 @@ type enrollment {
   site_short_name: String
   veterinary_medical_center: String
   patient_subgroup: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
   prior_therapies: [prior_therapy] @relation(name:"at_enrollment", direction:IN)
   prior_surgeries: [prior_surgery] @relation(name:"at_enrollment", direction:IN)
@@ -214,12 +204,11 @@ type file {
   file_type: String
   file_description: String
   file_format: String
-  file_size: Int
+  file_size: Float
   md5sum: String
   file_status: String
   uuid: String
   file_location: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
   study: study @relation(name:"of_study", direction:OUT)
   sample: sample @relation(name:"of_sample", direction:OUT)
@@ -236,19 +225,7 @@ type follow_up {
   treatment_since_last_contact: Boolean
   physical_exam_performed: Boolean
   physical_exam_changes: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
-}
-
-type human_relevance {
-  human_relevance_record_id: String
-  human_relevance_statement: String
-  relevant_human_cancer: String
-  relevant_experimental_therapeutic_intervention: String
-  relevant_human_genes: String
-  relevant_human_pathways: String
-  nci_link_to_relevant_human_cancer: String
-  study: study @relation(name:"of_study", direction:OUT)
 }
 
 type image {
@@ -261,7 +238,6 @@ type image_collection {
   image_collection_url: String
   repository_name: String
   collection_access: String
-  crdc_id: String
   study: study @relation(name:"of_study", direction:OUT)
 }
 
@@ -279,7 +255,6 @@ type off_study {
   date_last_medication_administration: String
   best_resp_vet_tx_tp_best_response: String
   date_of_best_response: String
-  crdc_id: String
   case: case @relation(name:"went_off_study", direction:IN)
 }
 
@@ -292,7 +267,6 @@ type off_treatment {
   date_last_medication_administration: String
   best_resp_vet_tx_tp_best_response: String
   date_of_best_response: String
-  crdc_id: String
   case: case @relation(name:"went_off_treatment", direction:IN)
 }
 
@@ -303,8 +277,7 @@ type physical_exam {
   pe_finding: String
   pe_comment: String
   phase_pe: String
-  assessment_timepoint: String
-  crdc_id: String
+  assessment_timepoint: Int
   enrollment: enrollment @relation(name:"at_enrollment", direction:OUT)
   visit: visit @relation(name:"on_visit", direction:OUT)
 }
@@ -313,7 +286,6 @@ type principal_investigator {
   pi_first_name: String
   pi_last_name: String
   pi_middle_initial: String
-  crdc_id: String
   studies: [study] @relation(name:"of_study", direction:OUT)
 }
 
@@ -324,7 +296,6 @@ type prior_surgery {
   surgical_finding: String
   residual_disease: String
   therapeutic_indicator: String
-  crdc_id: String
   enrollment: enrollment @relation(name:"at_enrollment", direction:OUT)
   next_prior_surgery: prior_surgery @relation(name:"next", direction:OUT)
   prior_prior_surgery: prior_surgery @relation(name:"next", direction:IN)
@@ -360,7 +331,6 @@ type prior_therapy {
   date_of_last_dose_any_therapy: String
   treatment_performed_at_site: Boolean
   treatment_performed_in_minimal_residual: Boolean
-  crdc_id: String
   enrollment: enrollment @relation(name:"at_enrollment", direction:OUT)
   next_prior_therapy: prior_therapy @relation(name:"next", direction:OUT)
   prior_prior_therapy: prior_therapy @relation(name:"next", direction:IN)
@@ -373,7 +343,6 @@ type program {
   program_full_description: String
   program_external_url: String
   program_sort_order: Int
-  crdc_id: String
   studies: [study] @relation(name:"member_of", direction:IN)
 }
 
@@ -384,14 +353,12 @@ type publication {
   journal_citation: String
   digital_object_id: String
   pubmed_id: Float
-  crdc_id: String
   study: study @relation(name:"of_study", direction:OUT)
 }
 
 type registration {
   registration_origin: String
   registration_id: String
-  crdc_id: String
   cases: [case] @relation(name:"of_case", direction:OUT)
 }
 
@@ -423,7 +390,6 @@ type sample {
   percentage_tumor: String
   sample_preservation: String
   comment: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
   visit: visit @relation(name:"on_visit", direction:OUT)
   assays: [assay] @relation(name:"of_sample", direction:IN)
@@ -442,12 +408,10 @@ type study {
   dates_of_conduct: String
   accession_id: String
   study_disposition: String
-  crdc_id: String
   study_arms: [study_arm] @relation(name:"member_of", direction:IN)
   program: program @relation(name:"member_of", direction:OUT)
   cases: [case] @relation(name:"member_of", direction:IN)
   cohorts: [cohort] @relation(name:"member_of", direction:IN)
-  human_relevance: human_relevance @relation(name:"of_study", direction:IN)
   study_sites: [study_site] @relation(name:"of_study", direction:IN)
   principal_investigators: [principal_investigator] @relation(name:"of_study", direction:IN)
   files: [file] @relation(name:"of_study", direction:IN)
@@ -457,10 +421,9 @@ type study {
 
 type study_arm {
   arm: String
+  ctep_treatment_assignment_code: String
   arm_description: String
   arm_id: String
-  ctep_treatment_assignment_code: String
-  crdc_id: String
   cohorts: [cohort] @relation(name:"member_of", direction:IN)
   study: study @relation(name:"member_of", direction:OUT)
   agents: [agent] @relation(name:"of_study_arm", direction:IN)
@@ -471,15 +434,13 @@ type study_site {
   site_short_name: String
   veterinary_medical_center: String
   registering_institution: String
-  crdc_id: String
   studies: [study] @relation(name:"of_study", direction:OUT)
 }
 
 type visit {
   visit_date: String
-  visit_number: Int
+  visit_number: String
   visit_id: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
   cycle: cycle @relation(name:"of_cycle", direction:OUT)
   agent_administrations: [agent_administration] @relation(name:"on_visit", direction:IN)
@@ -498,24 +459,23 @@ type vital_signs {
   body_temperature_unit: String
   body_temperature_original: Float
   body_temperature_original_unit: String
+  pulse: Int
+  pulse_unit: String
+  pulse_original: Int
+  pulse_original_unit: String
   respiration_rate: Int
   respiration_rate_unit: String
   respiration_rate_original: Int
   respiration_rate_original_unit: String
   respiration_pattern: String
-  pulse: Int
-  pulse_unit: String
-  pulse_original: Int
-  pulse_original_unit: String
-  pulse_ox: Float
-  pulse_ox_unit: String
-  pulse_ox_original: Float
-  pulse_ox_original_unit: String
   systolic_bp: Int
   systolic_bp_unit: String
   systolic_bp_original: Int
   systolic_bp_original_unit: String
-  ecg: String
+  pulse_ox: Float
+  pulse_ox_unit: String
+  pulse_ox_original: Float
+  pulse_ox_original_unit: String
   patient_weight: Float
   patient_weight_unit: String
   patient_weight_original: Float
@@ -525,9 +485,9 @@ type vital_signs {
   body_surface_area_original: Float
   body_surface_area_original_unit: String
   modified_ecog: String
-  assessment_timepoint: String
+  ecg: String
+  assessment_timepoint: Int
   phase: String
-  crdc_id: String
   visit: visit @relation(name:"on_visit", direction:OUT)
 }
 

--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -18,7 +18,6 @@ type adverse_event {
   other_attribution_description: String
   dose_limiting_toxicity: String
   unexpected_adverse_event: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
   agent: agent @relation(name:"of_agent", direction:OUT)
   cases: [case] @relation(name:"had_adverse_event", direction:IN)
@@ -29,7 +28,6 @@ type adverse_event {
 type agent {
   medication: String
   document_number: String
-  crdc_id: String
   study_arms: [study_arm] @relation(name:"of_study_arm", direction:OUT)
   agent_administrations: [agent_administration] @relation(name:"of_agent", direction:IN)
   adverse_events: [adverse_event] @relation(name:"of_agent", direction:IN)
@@ -76,6 +74,7 @@ type assay {
   sample: sample @relation(name:"of_sample", direction:OUT)
   files: [file] @relation(name:"of_assay", direction:IN)
   images: [image] @relation(name:"of_assay", direction:IN)
+  schema_validation_placeholder: String
 }
 
 type biospecimen_source {
@@ -230,6 +229,7 @@ type follow_up {
 
 type image {
   assay: assay @relation(name:"of_assay", direction:OUT)
+  schema_validation_placeholder: String
 }
 
 type image_collection {
@@ -243,6 +243,7 @@ type image_collection {
 
 type lab_exam {
   visit: visit @relation(name:"on_visit", direction:OUT)
+  schema_validation_placeholder: String
 }
 
 type off_study {
@@ -1112,6 +1113,7 @@ type CartChartData {
     fileType: [CartChartItem]
     fileFormat: [CartChartItem]
     fileAssociation: [CartChartItem]
+    schema_validation_placeholder: String
 }
 
 type CartOverviewData {


### PR DESCRIPTION
- the human relevance node and properties are currently only present in the `develop` branch of `icdc-model-tool`

- when running the model conversion script to add the human relevance type/query to the backend schema, the `icdc-model-tool` branch was still set to `develop`, which caused the addition of unintended property name/type changes in the backend schema (`icdc-doc.graphql` and `icdc.graphql`) that are clashing with the frontend GraphQL queries

- this PR reverts those unintended changes

- `schema_validation_placeholder` is a temporary fix for the GraphiQL UI crashing when GraphQL types only consist of `@relation`s