### PR TITLE
update backend code to accommodate data retriever service

### DIFF
--- a/src/main/resources/graphql/icdc-es.graphql
+++ b/src/main/resources/graphql/icdc-es.graphql
@@ -299,6 +299,19 @@ type GlobalSearchResult {
   model: [GS_Model]
 }
 
+type ExternalDataOverview {
+  entity_id: String
+  CRDCLinks: [CRDCLink]
+}
+
+scalar JSON
+
+type CRDCLink {
+  repository: String
+  url: String
+  metadata: JSON
+}
+
 schema {
   query: QueryType
 }
@@ -430,4 +443,12 @@ type QueryType {
     first: Int = 10
     offset: Int = 0
   ): String
+
+  externalDataOverview(
+    entity_id: String
+    order_by: String = ""
+    sort_direction: String = "ASC"
+    first: Int = 10
+    offset: Int = 0
+  ): [ExternalDataOverview]
 }

--- a/src/main/resources/yaml/es_indices_icdc.yml
+++ b/src/main/resources/yaml/es_indices_icdc.yml
@@ -1069,3 +1069,23 @@ Indices:
         type: text
       value_kw:
         type: keyword
+
+  - index_name: external_data
+    type: external
+    
+    mapping:
+      entity_id:
+        type: keyword
+      number_of_crdc_nodes:
+        type: integer
+      number_of_collections:
+        type: integer
+      CRDCLinks:
+        type: nested
+        properties:
+          repository:
+            type: keyword
+          url:
+            type: keyword
+          metadata:
+            type: object

--- a/src/main/resources/yaml/es_indices_icdc.yml
+++ b/src/main/resources/yaml/es_indices_icdc.yml
@@ -1076,10 +1076,6 @@ Indices:
     mapping:
       entity_id:
         type: keyword
-      number_of_crdc_nodes:
-        type: integer
-      number_of_collections:
-        type: integer
       CRDCLinks:
         type: nested
         properties:


### PR DESCRIPTION
- create new external data opensearch index with appropriate properties/mappings 
- create new opensearch query for getting external data from index
- add new graphql JSON scalar type to accommodate variability in metadata shape (tried to add `graphql-java-extended-scalars` dependency, but this required a newer version of `com.graphql-java`, which breaks the backend)