### PR TITLE
include studies of study files in file cart overview

### DIFF
--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -2241,7 +2241,8 @@ type QueryType {
     WITH
       COLLECT(f) AS files,
       COUNT(DISTINCT f) AS totalFiles,
-      COLLECT(DISTINCT studiesFromCases.clinical_study_designation) + COLLECT(DISTINCT studiesFromFiles.clinical_study_designation) AS studies,
+      [x IN COLLECT(DISTINCT studiesFromCases.clinical_study_designation) WHERE x IS NOT null] + 
+      [x IN COLLECT(DISTINCT studiesFromFiles.clinical_study_designation) WHERE x IS NOT null] AS studies,
       COUNT(DISTINCT c) AS totalCases,
       COLLECT(head(labels(parent))) AS parents
     CALL {

--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -2236,11 +2236,12 @@ type QueryType {
     WHERE f.uuid IN $file_uuids
     OPTIONAL MATCH (f)-->(parent)
     OPTIONAL MATCH (f)-[*]->(c:case)
-    OPTIONAL MATCH (s:study)<-[:member_of]-(c)
+    OPTIONAL MATCH (studiesFromCases:study)<-[:member_of]-(c)
+    OPTIONAL MATCH (f)-->(studiesFromFiles:study)
     WITH
       COLLECT(f) AS files,
       COUNT(DISTINCT f) AS totalFiles,
-      COLLECT(DISTINCT s.clinical_study_designation) AS studies,
+      COLLECT(DISTINCT studiesFromCases.clinical_study_designation) + COLLECT(DISTINCT studiesFromFiles.clinical_study_designation) AS studies,
       COUNT(DISTINCT c) AS totalCases,
       COLLECT(head(labels(parent))) AS parents
     CALL {

--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -2241,10 +2241,14 @@ type QueryType {
     WITH
       COLLECT(f) AS files,
       COUNT(DISTINCT f) AS totalFiles,
-      [x IN COLLECT(DISTINCT studiesFromCases.clinical_study_designation) WHERE x IS NOT null] + 
-      [x IN COLLECT(DISTINCT studiesFromFiles.clinical_study_designation) WHERE x IS NOT null] AS studies,
+      COLLECT(DISTINCT studiesFromCases.clinical_study_designation) + 
+      COLLECT(DISTINCT studiesFromFiles.clinical_study_designation) AS combinedStudies,
       COUNT(DISTINCT c) AS totalCases,
       COLLECT(head(labels(parent))) AS parents
+    UNWIND combinedStudies AS s
+    WITH files, totalFiles, totalCases, parents, s
+    WHERE s IS NOT NULL
+    WITH files, totalFiles, totalCases, parents, COLLECT(DISTINCT s) AS studies
     CALL {
       WITH files
       UNWIND files AS f

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -1812,10 +1812,14 @@ type QueryType {
     WITH
       COLLECT(f) AS files,
       COUNT(DISTINCT f) AS totalFiles,
-      [x IN COLLECT(DISTINCT studiesFromCases.clinical_study_designation) WHERE x IS NOT null] + 
-      [x IN COLLECT(DISTINCT studiesFromFiles.clinical_study_designation) WHERE x IS NOT null] AS studies,
+      COLLECT(DISTINCT studiesFromCases.clinical_study_designation) + 
+      COLLECT(DISTINCT studiesFromFiles.clinical_study_designation) AS combinedStudies,
       COUNT(DISTINCT c) AS totalCases,
       COLLECT(head(labels(parent))) AS parents
+    UNWIND combinedStudies AS s
+    WITH files, totalFiles, totalCases, parents, s
+    WHERE s IS NOT NULL
+    WITH files, totalFiles, totalCases, parents, COLLECT(DISTINCT s) AS studies
     CALL {
       WITH files
       UNWIND files AS f

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -1807,11 +1807,12 @@ type QueryType {
     WHERE f.uuid IN $file_uuids
     OPTIONAL MATCH (f)-->(parent)
     OPTIONAL MATCH (f)-[*]->(c:case)
-    OPTIONAL MATCH (s:study)<-[:member_of]-(c)
+    OPTIONAL MATCH (studiesFromCases:study)<-[:member_of]-(c)
+    OPTIONAL MATCH (f)-->(studiesFromFiles:study)
     WITH
       COLLECT(f) AS files,
       COUNT(DISTINCT f) AS totalFiles,
-      COLLECT(DISTINCT s.clinical_study_designation) AS studies,
+      COLLECT(DISTINCT studiesFromCases.clinical_study_designation) + COLLECT(DISTINCT studiesFromFiles.clinical_study_designation) AS studies,
       COUNT(DISTINCT c) AS totalCases,
       COLLECT(head(labels(parent))) AS parents
     CALL {

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -1812,7 +1812,8 @@ type QueryType {
     WITH
       COLLECT(f) AS files,
       COUNT(DISTINCT f) AS totalFiles,
-      COLLECT(DISTINCT studiesFromCases.clinical_study_designation) + COLLECT(DISTINCT studiesFromFiles.clinical_study_designation) AS studies,
+      [x IN COLLECT(DISTINCT studiesFromCases.clinical_study_designation) WHERE x IS NOT null] + 
+      [x IN COLLECT(DISTINCT studiesFromFiles.clinical_study_designation) WHERE x IS NOT null] AS studies,
       COUNT(DISTINCT c) AS totalCases,
       COLLECT(head(labels(parent))) AS parents
     CALL {


### PR DESCRIPTION
- previous version of `cartOverview` only returned studies linked to case files in `studiesInCart`
- this fix updates the query to include studies of any study files present in the cart in `studiesInCart`