### PR TITLE
revert case_record_id and inadvertent schema churn

### DIFF
--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -86,7 +86,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         map.put("file_name", "name");
         map.put("drs_uri", "drs_uri");
         map.put("clinical_study_designation", "Study Code");
-        map.put("case_record_id", "Case ID");
+        map.put("case_id", "Case ID");
         STATIC_PROPS = Collections.unmodifiableMap(map);
     }
 
@@ -159,8 +159,8 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
     }
 
     private Map<String, Object> searchCases(Map<String, Object> params) throws IOException {
-        // cast case_record_ids param to lowercase to standardize user input
-        Map<String, Object> formattedParams = formatParams(params, "case_record_ids", "case_record_id_lc");
+        // cast case_ids param to lowercase to standardize user input
+        Map<String, Object> formattedParams = formatParams(params, "case_ids", "case_id_lc");
         
         final String AGG_NAME = "agg_name";
         final String AGG_ENDPOINT = "agg_endpoint";
@@ -319,7 +319,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         int numberOfCases = caseCountResult.get("count").getAsInt();
 
         // get IDs associated with corresponding counts
-        List<String> caseIds = fetchIdsFromResults(query, CASES_END_POINT, "case_record_ids", numberOfCases);
+        List<String> caseIds = fetchIdsFromResults(query, CASES_END_POINT, "case_ids", numberOfCases);
         List<String> sampleIds = fetchIdsFromResults(query, SAMPLES_END_POINT, "sample_ids", numberOfSamples);
         List<String> fileIds = fetchIdsFromResults(query, FILES_END_POINT, "file_uuids", numberOfFiles);
         List<String> studyFileIds = fetchIdsFromResults(studyFileQuery, FILES_END_POINT, "file_uuids", numberOfStudyFiles);
@@ -464,11 +464,11 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
     }
 
     private List<Map<String, Object>> caseOverview(Map<String, Object> params) throws IOException {
-        Map<String, Object> formattedParams = formatParams(params, "case_record_ids", "case_record_id_lc");
+        Map<String, Object> formattedParams = formatParams(params, "case_ids", "case_id_lc");
 
         final String[][] PROPERTIES = new String[][]{
-                new String[]{"case_record_id", "case_record_id_kw"},
-                new String[]{"case_record_id_lc", "case_record_id_lc"},
+                new String[]{"case_id", "case_id_kw"},
+                new String[]{"case_id_lc", "case_id_lc"},
                 new String[]{"study_code", "study_code"},
                 new String[]{"study_type", "study_type"},
                 new String[]{"cohort", "cohort"},
@@ -496,7 +496,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 new String[]{"arm", "arm"}
         };
 
-        String defaultSort = "case_record_id_lc"; // Default sort order
+        String defaultSort = "case_id_lc"; // Default sort order
 
         Map<String, String> mapping = Map.ofEntries(
                 Map.entry("study_code", "study_code"),
@@ -512,20 +512,20 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 Map.entry("weight", "weight"),
                 Map.entry("response_to_treatment", "response_to_treatment"),
                 Map.entry("other_cases", "other_cases"),
-                Map.entry("case_record_id", "case_record_id_kw"),
-                Map.entry("case_record_id_lc", "case_record_id_lc")
+                Map.entry("case_id", "case_id_kw"),
+                Map.entry("case_id_lc", "case_id_lc")
         );
 
         return overview(CASES_END_POINT, formattedParams, PROPERTIES, defaultSort, mapping);
     }
 
     private List<Map<String, Object>> sampleOverview(Map<String, Object> params) throws IOException {
-        Map<String, Object> formattedParams = formatParams(params, "case_record_ids", "case_record_id_lc");
+        Map<String, Object> formattedParams = formatParams(params, "case_ids", "case_id_lc");
 
         final String[][] PROPERTIES = new String[][]{
                 new String[]{"sample_id", "sample_ids"},
-                new String[]{"case_record_id", "case_record_ids"},
-                new String[]{"case_record_id_lc", "case_record_id_lc"},
+                new String[]{"case_id", "case_ids"},
+                new String[]{"case_id_lc", "case_id_lc"},
                 new String[]{"breed", "breed"},
                 new String[]{"diagnosis", "diagnosis"},
                 new String[]{"sample_site", "sample_site"},
@@ -566,7 +566,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
 
         Map<String, String> mapping = Map.ofEntries(
                 Map.entry("sample_id", "sample_ids"),
-                Map.entry("case_record_id", "case_record_ids"),
+                Map.entry("case_id", "case_ids"),
                 Map.entry("breed", "breed"),
                 Map.entry("diagnosis", "diagnosis"),
                 Map.entry("sample_site", "sample_site"),
@@ -577,14 +577,14 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 Map.entry("percentage_tumor", "percentage_tumor"),
                 Map.entry("necropsy_sample", "necropsy_sample"),
                 Map.entry("sample_preservation", "sample_preservation"),
-                Map.entry("case_record_id_lc", "case_record_id_lc")
+                Map.entry("case_id_lc", "case_id_lc")
         );
 
         return overview(SAMPLES_END_POINT, formattedParams, PROPERTIES, defaultSort, mapping);
     }
 
     private List<Map<String, Object>> fileOverview(Map<String, Object> params) throws IOException {
-        Map<String, Object> formattedParams = formatParams(params, "case_record_ids", "case_record_id_lc");
+        Map<String, Object> formattedParams = formatParams(params, "case_ids", "case_id_lc");
 
         // Following String array of arrays should be in form of "GraphQL_field_name", "ES_field_name"
         final String[][] PROPERTIES = new String[][]{
@@ -594,8 +594,8 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 new String[]{"file_description", "file_description"},
                 new String[]{"file_format", "file_format"},
                 new String[]{"file_size", "file_size"},
-                new String[]{"case_record_id", "case_record_ids"},
-                new String[]{"case_record_id_lc", "case_record_id_lc"},
+                new String[]{"case_id", "case_ids"},
+                new String[]{"case_id_lc", "case_id_lc"},
                 new String[]{"breed", "breed"},
                 new String[]{"diagnosis", "diagnosis"},
                 new String[]{"study_code", "study_code"},
@@ -644,13 +644,13 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 Map.entry("file_description", "file_description"),
                 Map.entry("file_format", "file_format"),
                 Map.entry("file_size", "file_size"),
-                Map.entry("case_record_id", "case_record_ids"),
+                Map.entry("case_id", "case_ids"),
                 Map.entry("breed", "breed"),
                 Map.entry("diagnosis", "diagnosis"),
                 Map.entry("study_code", "study_code"),
                 Map.entry("file_uuid", "file_uuids"),
                 Map.entry("access_file", "file_size"),
-                Map.entry("case_record_id_lc", "case_record_id_lc")
+                Map.entry("case_id_lc", "case_id_lc")
         );
 
         return overview(FILES_END_POINT, formattedParams, PROPERTIES, defaultSort, mapping);
@@ -836,13 +836,13 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 GS_COUNT_RESULT_FIELD, "sample_count",
                 GS_RESULT_FIELD, "samples",
                 GS_SEARCH_FIELD, List.of("sample_ids_txt", "program_name", "clinical_study_designation",
-                    "case_record_ids_txt", "sample_site_txt", "physical_sample_type_txt", "general_sample_pathology_txt"),
+                    "case_ids_txt", "sample_site_txt", "physical_sample_type_txt", "general_sample_pathology_txt"),
                 GS_SORT_FIELD, "sample_ids",
                 GS_COLLECT_FIELDS, new String[][]{
                         new String[]{"sample_id", "sample_ids_txt"},
                         new String[]{"program_name", "program_name"},
                         new String[]{"clinical_study_designation", "clinical_study_designation"},
-                        new String[]{"case_record_id", "case_record_ids_txt"},
+                        new String[]{"case_id", "case_ids_txt"},
                         new String[]{"sample_site", "sample_site_txt"},
                         new String[]{"physical_sample_type", "physical_sample_type_txt"},
                         new String[]{"general_sample_pathology", "general_sample_pathology_txt"}
@@ -854,11 +854,11 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 GS_COUNT_ENDPOINT, CASES_COUNT_END_POINT,
                 GS_COUNT_RESULT_FIELD, "case_count",
                 GS_RESULT_FIELD, "cases",
-                GS_SEARCH_FIELD, List.of("case_record_ids", "program_name", "clinical_study_designation",
+                GS_SEARCH_FIELD, List.of("case_ids", "program_name", "clinical_study_designation",
                     "disease_term", "breed_txt"),
-                GS_SORT_FIELD, "case_record_id_kw",
+                GS_SORT_FIELD, "case_id_kw",
                 GS_COLLECT_FIELDS, new String[][]{
-                        new String[]{"case_record_id", "case_record_ids"},
+                        new String[]{"case_id", "case_ids"},
                         new String[]{"program_name", "program_name"},
                         new String[]{"clinical_study_designation", "clinical_study_designation"},
                         new String[]{"disease_term", "disease_term"},
@@ -872,14 +872,14 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 GS_COUNT_RESULT_FIELD, "file_count",
                 GS_RESULT_FIELD, "files",
                 GS_SEARCH_FIELD, List.of( "sample_ids_txt", "file_name_txt",
-                        "file_type_txt", "case_record_ids_txt", "program_name", "clinical_study_designation_txt"),
+                        "file_type_txt", "case_ids_txt", "program_name", "clinical_study_designation_txt"),
                 GS_SORT_FIELD, "file_name",
                 GS_COLLECT_FIELDS, new String[][]{
                         new String[]{"sample_id", "sample_ids_txt"},
                         new String[]{"file_name", "file_name_txt"},
                         new String[]{"file_type", "file_type_txt"},
                         new String[]{"file_association", "file_association"},
-                        new String[]{"case_record_id", "case_record_ids_txt"},
+                        new String[]{"case_id", "case_ids_txt"},
                         new String[]{"program_name", "program_name"},
                         new String[]{"clinical_study_designation", "clinical_study_designation_txt"}
                 },
@@ -1156,7 +1156,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
                 Map.entry("file_description", "file_description"),
                 Map.entry("file_format", "file_format"),
                 Map.entry("file_size", "file_size"),
-                Map.entry("case_record_ids", "case_record_ids"),
+                Map.entry("case_ids", "case_ids"),
                 Map.entry("breed", "breed"),
                 Map.entry("diagnosis", "diagnosis"),
                 Map.entry("study_code", "study_code"),

--- a/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
+++ b/src/main/java/gov/nih/nci/icdc/IcdcEsFilter.java
@@ -342,7 +342,7 @@ public class IcdcEsFilter extends AbstractPrivateESDataFetcher {
         data.put("volumeOfData", getVolumeOfData(formattedParams, "file_size", FILES_END_POINT));
 
         data.put("programsAndStudies", programsAndStudies(formattedParams));
-        data.put("caseRecordIds", caseIds);
+        data.put("caseIds", caseIds);
         data.put("sampleIds", sampleIds);
         data.put("fileIds", fileIds);
         data.put("studyFileIds", studyFileIds);

--- a/src/main/resources/graphql/icdc-doc.graphql
+++ b/src/main/resources/graphql/icdc-doc.graphql
@@ -1,5 +1,4 @@
 type adverse_event {
-  adverse_event_record_id: String
   day_in_cycle: Int
   date_of_onset: String
   existing_adverse_event: String
@@ -19,78 +18,116 @@ type adverse_event {
   other_attribution_description: String
   dose_limiting_toxicity: String
   unexpected_adverse_event: String
-  crdc_id: String
   case: case 
+  agent: agent 
   cases: [case] 
   next_adverse_event: adverse_event 
   prior_adverse_event: adverse_event 
 }
 
+type agent {
+  medication: String
+  document_number: String
+  study_arms: [study_arm] 
+  agent_administrations: [agent_administration] 
+  adverse_events: [adverse_event] 
+}
+
+type agent_administration {
+  document_number: String
+  medication: String
+  route_of_administration: String
+  medication_lot_number: String
+  medication_vial_id: String
+  medication_actual_units_of_measure: String
+  medication_duration: Float
+  medication_duration_unit: String
+  medication_duration_original: Float
+  medication_duration_original_unit: String
+  medication_units_of_measure: String
+  medication_actual_dose: Float
+  medication_actual_dose_unit: String
+  medication_actual_dose_original: Float
+  medication_actual_dose_original_unit: String
+  phase: String
+  start_time: String
+  stop_time: String
+  dose_level: Float
+  dose_level_unit: String
+  dose_level_original: Float
+  dose_level_original_unit: String
+  dose_units_of_measure: String
+  date_of_missed_dose: String
+  medication_missed_dose: String
+  missed_dose_amount: Float
+  missed_dose_amount_unit: String
+  missed_dose_amount_original: Float
+  missed_dose_amount_original_unit: String
+  missed_dose_units_of_measure: String
+  medication_course_number: String
+  comment: String
+  agent: agent 
+  visit: visit 
+}
+
+type assay {
+  sample: sample 
+  files: [file] 
+  images: [image] 
+}
+
 type biospecimen_source {
   biospecimen_repository_acronym: String
   biospecimen_repository_full_name: String
-  crdc_id: String
 }
 
 type canine_individual {
   canine_individual_id: String
-  crdc_id: String
   cases: [case] 
 }
 
 type case {
-  case_record_id: String
+  case_id: String
   patient_id: String
   patient_first_name: String
-  crdc_id: String
   cohort: cohort 
   study: study 
   enrollment: enrollment 
   demographic: demographic 
-  diagnosis: diagnosis 
+  diagnoses: [diagnosis] 
   cycles: [cycle] 
+  follow_ups: [follow_up] 
   samples: [sample] 
   files: [file] 
   visits: [visit] 
   adverse_events: [adverse_event] 
   registrations: [registration] 
-  consent_group: consent_group 
   study_arm: study_arm 
   adverse_event: adverse_event 
+  off_study: off_study 
+  off_treatment: off_treatment 
   canine_individual: canine_individual 
 }
 
 type cohort {
-  cohort_record_id: String
   cohort_description: String
   cohort_dose: String
-  crdc_id: String
+  cohort_id: String
   cases: [case] 
   study_arm: study_arm 
   study: study 
 }
 
-type consent_group {
-  consent_group_record_id: String
-  consent_group_name: String
-  consent_group_number: Int
-  crdc_id: String
-  cases: [case] 
-  study: study 
-}
-
 type cycle {
-  cycle_record_id: String
   cycle_number: Int
   date_of_cycle_start: String
   date_of_cycle_end: String
-  crdc_id: String
   case: case 
   visits: [visit] 
 }
 
 type demographic {
-  demographic_record_id: String
+  demographic_id: String
   breed: String
   additional_breed_detail: String
   patient_age_at_enrollment: Float
@@ -104,12 +141,11 @@ type demographic {
   weight_original: Float
   weight_original_unit: String
   neutered_indicator: String
-  crdc_id: String
   case: case 
 }
 
 type diagnosis {
-  diagnosis_record_id: String
+  diagnosis_id: String
   disease_term: String
   primary_disease_site: String
   stage_of_disease: String
@@ -123,14 +159,12 @@ type diagnosis {
   follow_up_data: String
   concurrent_disease: String
   concurrent_disease_type: String
-  crdc_id: String
   case: case 
   files: [file] 
 }
 
 type disease_extent {
-  disease_extent_record_id: String
-  lesion_number: Int
+  lesion_number: String
   lesion_site: String
   lesion_description: String
   previously_irradiated: String
@@ -143,22 +177,20 @@ type disease_extent {
   longest_measurement_unit: String
   longest_measurement_original: Float
   longest_measurement_original_unit: String
-  evaluation_number: Int
+  evaluation_number: String
   evaluation_code: String
-  crdc_id: String
   visit: visit 
 }
 
 type enrollment {
-  enrollment_record_id: String
+  enrollment_id: String
+  date_of_registration: String
+  registering_institution: String
   initials: String
+  date_of_informed_consent: String
   site_short_name: String
   veterinary_medical_center: String
-  registering_institution: String
-  date_of_registration: String
-  date_of_informed_consent: String
   patient_subgroup: String
-  crdc_id: String
   case: case 
   prior_therapies: [prior_therapy] 
   prior_surgeries: [prior_surgery] 
@@ -170,16 +202,28 @@ type file {
   file_type: String
   file_description: String
   file_format: String
-  file_size: Int
+  file_size: Float
   md5sum: String
   file_status: String
   uuid: String
   file_location: String
-  crdc_id: String
   case: case 
   study: study 
   sample: sample 
+  assay: assay 
   diagnosis: diagnosis 
+}
+
+type follow_up {
+  document_number: String
+  date_of_last_contact: String
+  patient_status: String
+  explain_unknown_status: String
+  contact_type: String
+  treatment_since_last_contact: Boolean
+  physical_exam_performed: Boolean
+  physical_exam_changes: String
+  case: case 
 }
 
 type human_relevance {
@@ -193,45 +237,80 @@ type human_relevance {
   study: study 
 }
 
+type image {
+  assay: assay 
+}
+
+type image_collection {
+  image_collection_name: String
+  image_type_included: String
+  image_collection_url: String
+  repository_name: String
+  collection_access: String
+  study: study 
+}
+
+type lab_exam {
+  visit: visit 
+}
+
+type off_study {
+  document_number: String
+  date_off_study: String
+  reason_off_study: String
+  date_of_disease_progression: String
+  date_off_treatment: String
+  best_resp_vet_tx_tp_secondary_response: String
+  date_last_medication_administration: String
+  best_resp_vet_tx_tp_best_response: String
+  date_of_best_response: String
+  case: case 
+}
+
+type off_treatment {
+  document_number: String
+  date_off_treatment: String
+  reason_off_treatment: String
+  date_of_disease_progression: String
+  best_resp_vet_tx_tp_secondary_response: String
+  date_last_medication_administration: String
+  best_resp_vet_tx_tp_best_response: String
+  date_of_best_response: String
+  case: case 
+}
+
 type physical_exam {
-  physical_exam_record_id: String
   date_of_examination: String
   day_in_cycle: Int
   body_system: String
   pe_finding: String
   pe_comment: String
   phase_pe: String
-  assessment_timepoint: String
-  crdc_id: String
+  assessment_timepoint: Int
   enrollment: enrollment 
   visit: visit 
 }
 
 type principal_investigator {
-  person_record_id: String
   pi_first_name: String
   pi_last_name: String
   pi_middle_initial: String
-  crdc_id: String
   studies: [study] 
 }
 
 type prior_surgery {
-  prior_surgery_record_id: String
   date_of_surgery: String
   procedure: String
   anatomical_site_of_surgery: String
   surgical_finding: String
   residual_disease: String
   therapeutic_indicator: String
-  crdc_id: String
   enrollment: enrollment 
   next_prior_surgery: prior_surgery 
   prior_prior_surgery: prior_surgery 
 }
 
 type prior_therapy {
-  prior_therapy_record_id: String
   date_of_first_dose: String
   date_of_last_dose: String
   agent_name: String
@@ -261,7 +340,6 @@ type prior_therapy {
   date_of_last_dose_any_therapy: String
   treatment_performed_at_site: Boolean
   treatment_performed_in_minimal_residual: Boolean
-  crdc_id: String
   enrollment: enrollment 
   next_prior_therapy: prior_therapy 
   prior_prior_therapy: prior_therapy 
@@ -274,7 +352,6 @@ type program {
   program_full_description: String
   program_external_url: String
   program_sort_order: Int
-  crdc_id: String
   studies: [study] 
 }
 
@@ -285,14 +362,12 @@ type publication {
   journal_citation: String
   digital_object_id: String
   pubmed_id: Float
-  crdc_id: String
   study: study 
 }
 
 type registration {
   registration_origin: String
-  registration_record_id: String
-  crdc_id: String
+  registration_id: String
   cases: [case] 
 }
 
@@ -324,9 +399,9 @@ type sample {
   percentage_tumor: String
   sample_preservation: String
   comment: String
-  crdc_id: String
   case: case 
   visit: visit 
+  assays: [assay] 
   files: [file] 
   next_sample: sample 
   prior_sample: sample 
@@ -342,26 +417,26 @@ type study {
   dates_of_conduct: String
   accession_id: String
   study_disposition: String
-  crdc_id: String
   study_arms: [study_arm] 
   program: program 
   cases: [case] 
   cohorts: [cohort] 
-  human_relevance: human_relevance 
+  human_relevance: human_relevance
   study_sites: [study_site] 
   principal_investigators: [principal_investigator] 
   files: [file] 
+  image_collections: [image_collection] 
   publications: [publication] 
-  NONE: [consent_group] 
 }
 
 type study_arm {
-  arm_id: String
   arm: String
+  ctep_treatment_assignment_code: String
   arm_description: String
-  crdc_id: String
+  arm_id: String
   cohorts: [cohort] 
   study: study 
+  agents: [agent] 
   cases: [case] 
 }
 
@@ -369,19 +444,19 @@ type study_site {
   site_short_name: String
   veterinary_medical_center: String
   registering_institution: String
-  crdc_id: String
   studies: [study] 
 }
 
 type visit {
-  visit_record_id: String
   visit_date: String
-  visit_number: Int
-  crdc_id: String
+  visit_number: String
+  visit_id: String
   case: case 
   cycle: cycle 
+  agent_administrations: [agent_administration] 
   samples: [sample] 
   physical_exams: [physical_exam] 
+  lab_exams: [lab_exam] 
   disease_extents: [disease_extent] 
   vital_signs: [vital_signs] 
   next_visit: visit 
@@ -389,30 +464,28 @@ type visit {
 }
 
 type vital_signs {
-  vital_signs_record_id: String
   date_of_vital_signs: String
   body_temperature: Float
   body_temperature_unit: String
   body_temperature_original: Float
   body_temperature_original_unit: String
+  pulse: Int
+  pulse_unit: String
+  pulse_original: Int
+  pulse_original_unit: String
   respiration_rate: Int
   respiration_rate_unit: String
   respiration_rate_original: Int
   respiration_rate_original_unit: String
   respiration_pattern: String
-  pulse: Int
-  pulse_unit: String
-  pulse_original: Int
-  pulse_original_unit: String
-  pulse_ox: Float
-  pulse_ox_unit: String
-  pulse_ox_original: Float
-  pulse_ox_original_unit: String
   systolic_bp: Int
   systolic_bp_unit: String
   systolic_bp_original: Int
   systolic_bp_original_unit: String
-  ecg: String
+  pulse_ox: Float
+  pulse_ox_unit: String
+  pulse_ox_original: Float
+  pulse_ox_original_unit: String
   patient_weight: Float
   patient_weight_unit: String
   patient_weight_original: Float
@@ -422,8 +495,9 @@ type vital_signs {
   body_surface_area_original: Float
   body_surface_area_original_unit: String
   modified_ecog: String
-  assessment_timepoint: String
-  crdc_id: String
+  ecg: String
+  assessment_timepoint: Int
+  phase: String
   visit: visit 
 }
 
@@ -443,7 +517,7 @@ type CaseDetail {
     arm: String
     ctep_treatment_assignment_code: String
     cohort_description: String
-    case_record_id: String
+    case_id: String
     patient_id: String
     patient_first_name: String
     breed: String
@@ -504,7 +578,7 @@ type FileOverview2 {
 }
 
 type CaseOverview {
-    case_record_id: String
+    case_id: String
     program: String
     study_code: String
     study_type: String
@@ -526,7 +600,7 @@ type CaseOverview {
 
 
 type FilesOfCase{
-    case_record_id: String
+    case_id: String
     parent:String
     file_name: String
     file_type: String
@@ -556,7 +630,7 @@ type FileDetail {
     arm: String
     cohort_description: String
     cohort_dose: String
-    case_record_id: String
+    case_id: String
     breed: String
     weight: Float
     sex: String
@@ -618,7 +692,7 @@ type FileInList {
     file_description: String
     file_format: String
     file_size: Float
-    case_record_id: String
+    case_id: String
     breed: String
     diagnosis: String
     study_code: String
@@ -684,7 +758,7 @@ type FileOverview {
     file_description: String
     file_format: String
     file_size: Float
-    case_record_id: String
+    case_id: String
     breed: String
     diagnosis: String
     study_code: String
@@ -726,7 +800,7 @@ type FileOverview {
 
 type SampleOverview {
     sample_id: String
-    case_record_id: String
+    case_id: String
     breed: String
     diagnosis: String
     sample_site: String
@@ -764,7 +838,7 @@ type SampleOverview {
 }
 
 type CaseOverview2 {
-    case_record_id: String
+    case_id: String
     study_code: String
     study_type: String
     cohort: String
@@ -800,7 +874,7 @@ type GroupCount {
 
 type MultiStudyCases {
     individualId: String
-    caseRecordIds: [String]
+    caseIds: [String]
     sampleIds: [String]
     fileIds: [String]
     studyFileIds: [String]
@@ -838,12 +912,12 @@ type CycleNodeData {
     cycle_number: Int
     date_of_cycle_end: String
     crf_id: String
-    case_record_id: String
+    case_id: String
     date_of_cycle_start: String
 }
 
 type VisitNodeData {
-    case_record_id: String
+    case_id: String
     visit_date: String
     visit_number: Int
     visit_id: String
@@ -861,7 +935,7 @@ type FollowUpNodeData {
 }
 
 type AdverseEventNodeData {
-    case_record_id: String
+    case_id: String
     day_in_cycle: Int
     dose_limiting_toxicity: String
     unexpected_adverse_event: String
@@ -936,7 +1010,7 @@ type PriorTherapyNodeData {
 }
 
 type PriorSurgeryNodeData {
-    case_record_id: String
+    case_id: String
     date_of_surgery: String
     procedure: String
     anatomical_site_of_surgery: String
@@ -946,7 +1020,7 @@ type PriorSurgeryNodeData {
 }
 
 type PhysicalExamNodeData {
-    case_record_id: String
+    case_id: String
     date_of_examination: String
     day_in_cycle: Int
     body_system: String
@@ -962,7 +1036,7 @@ type AgentNodeData {
 }
 
 type DiseaseExtentNodeData {
-    case_record_id: String
+    case_id: String
     lesion_number: Int
     lesion_site: String
     lesion_description: String
@@ -1012,7 +1086,7 @@ type VitalSignsNodeData {
     body_surface_area_original_unit: String
     patient_weight: Float
     patient_weight_unit: String
-    case_record_id: String
+    case_id: String
     time_of_observation: String
     pulse_original_unit: String
     respiration_rate_original_unit: String
@@ -1081,7 +1155,7 @@ type QueryType {
     numberOfPrograms: Int 
     numberOfAliquots: Int 
     volumeOfData: Float 
-    volumeOfDataOfCase(case_record_id: String!): Float 
+    volumeOfDataOfCase(case_id: String!): Float 
     volumeOfDataOfProgram(program_id: String!): Float 
     volumeOfDataOfStudy(study_code: String!): Float 
 
@@ -1092,19 +1166,19 @@ type QueryType {
     fileCountOfStudyFiles(study_code: String!): Int 
     aliquotCountOfStudy(study_code: String!): Int 
     caseCountOfStudy(study_code: String!): Int 
-    fileCountOfCase(case_record_id: String!): Int 
-    studyFileCountOfCase(case_record_id: String!): Int 
-    aliquotCountOfCase(case_record_id: String!): Int 
+    fileCountOfCase(case_id: String!): Int 
+    studyFileCountOfCase(case_id: String!): Int 
+    aliquotCountOfCase(case_id: String!): Int 
     sampleCountOfProgram(program_id: String!): Int 
     fileCountOfProgram(program_id: String!): Int 
     studyFileCountOfProgram(program_id: String!): Int 
     aliquotCountOfProgram(program_id: String!): Int 
     studyCountOfProgram(program_id: String!): Int 
     caseCountOfProgram(program_id: String!): Int 
-    sampleCountOfCase(case_record_id: String!): Int 
+    sampleCountOfCase(case_id: String!): Int 
 
     programCountOfStudy(study_code: String!): Int 
-    programsCountOfCase(case_record_id: String!): Int 
+    programsCountOfCase(case_id: String!): Int 
 
     filesInList(uuids: [String], order_by: String = ""): [FileInList] 
 
@@ -1115,24 +1189,24 @@ type QueryType {
 
     studiesByProgram: [StudyOfProgram] 
 
-    filesOfCase(case_record_id: String!): [FilesOfCase] 
+    filesOfCase(case_id: String!): [FilesOfCase] 
 
-    filesOfCases(case_record_ids: [String!]!): [FilesOfCase] 
+    filesOfCases(case_ids: [String!]!): [FilesOfCase] 
 
-    multiStudyCases(case_record_id: String): MultiStudyCases 
+    multiStudyCases(case_id: String): MultiStudyCases 
 
-    caseDetail(case_record_id: String): CaseDetail 
+    caseDetail(case_id: String): CaseDetail 
 
     caseOverview(study_codes: [String] = [""], breeds: [String] = [""], diagnoses: [String] = [""], sexes: [String] = [""]): [CaseOverview] 
 
-    casesInList(case_record_ids: [String!]!): [CaseOverview] 
+    casesInList(case_ids: [String!]!): [CaseOverview] 
 
     studyDetail(study_code: String!): [StudyDetail] 
 
     "Find nodes with parameters"
     casesByStudyId(study_id: String!): [case] 
 
-    samplesByCaseRecordId(case_record_id: String!): [sample] 
+    samplesByCaseId(case_id: String!): [sample] 
 
     filesBySampleId(sample_id: String!): [file] 
 
@@ -1152,7 +1226,7 @@ type QueryType {
 
     fileIdsFromFileNameDesc(file_name: [String] = [""], order_by: String ="file_name"): [FileOverview] 
 
-    unifiedViewData(case_record_ids: [String] = [""]): UnifiedCounts 
+    unifiedViewData(case_ids: [String] = [""]): UnifiedCounts 
 
     studySampleSiteCount(study_codes: [String]): [GroupCount] 
 

--- a/src/main/resources/graphql/icdc-es.graphql
+++ b/src/main/resources/graphql/icdc-es.graphql
@@ -1,6 +1,6 @@
 type CaseOverviewES {
-  case_record_id: String
-  case_record_id_lc: String
+  case_id: String
+  case_id_lc: String
   study_code: String
   study_type: String
   cohort: String
@@ -30,8 +30,8 @@ type CaseOverviewES {
 
 type SampleOverviewES {
   sample_id: String
-  case_record_id: String
-  case_record_id_lc: String
+  case_id: String
+  case_id_lc: String
   breed: String
   diagnosis: String
   sample_site: String
@@ -75,8 +75,8 @@ type FileOverviewES {
   file_description: String
   file_format: String
   file_size: Float
-  case_record_id: String
-  case_record_id_lc: String
+  case_id: String
+  case_id_lc: String
   breed: String
   diagnosis: String
   study_code: String
@@ -117,7 +117,7 @@ type FileOverviewES {
 }
 
 type CaseOverviewES2 {
-  case_record_id: String
+  case_id: String
   study_code: String
   study_type: String
   cohort: String
@@ -229,7 +229,7 @@ type GS_Study {
 
 type GS_Cases {
   type: String
-  case_record_id: String
+  case_id: String
   program_name: String
   clinical_study_designation: String
   disease_term: String
@@ -241,7 +241,7 @@ type GS_Sample {
   sample_id: String
   program_name: String
   clinical_study_designation: String
-  case_record_id: String
+  case_id: String
   sample_site: String
   physical_sample_type: String
   general_sample_pathology: String
@@ -254,7 +254,7 @@ type GS_File {
   file_association: String
   program_name: String
   clinical_study_designation: String
-  case_record_id: String
+  case_id: String
   sample_id: String
 }
 
@@ -320,7 +320,7 @@ schema {
 
 type QueryType {
   searchCases(
-    case_record_ids: [String] = []
+    case_ids: [String] = []
     program: [String] = []
     study: [String] = []
     study_type: [String] = []
@@ -345,7 +345,7 @@ type QueryType {
   ): SearchResult
 
   caseOverview(
-    case_record_ids: [String] = []
+    case_ids: [String] = []
     program: [String] = []
     study: [String] = []
     study_type: [String] = []
@@ -366,14 +366,14 @@ type QueryType {
     file_association: [String] = []
     file_type: [String] = []
     file_format: [String] = []
-    order_by: String = "case_record_ids"
+    order_by: String = "case_ids"
     sort_direction: String = "ASC"
     first: Int = 10
     offset: Int = 0
   ): [CaseOverviewES]
 
   sampleOverview(
-    case_record_ids: [String] = []
+    case_ids: [String] = []
     sample_ids: [String] = []
     program: [String] = []
     study: [String] = []
@@ -403,7 +403,7 @@ type QueryType {
 
   fileOverview(
     file_level: [String] = []
-    case_record_ids: [String] = []
+    case_ids: [String] = []
     sample_ids: [String] = []
     file_uuids: [String] = []
     program: [String] = []

--- a/src/main/resources/graphql/icdc-es.graphql
+++ b/src/main/resources/graphql/icdc-es.graphql
@@ -170,7 +170,7 @@ type SearchResult {
   numberOfStudyFiles: Int
   numberOfAliquots: Int
   volumeOfData: Float
-  caseRecordIds: [String]
+  caseIds: [String]
   sampleIds: [String]
   fileIds: [String]
   studyFileIds: [String]

--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -1,5 +1,4 @@
 type adverse_event {
-  adverse_event_record_id: String
   day_in_cycle: Int
   date_of_onset: String
   existing_adverse_event: String
@@ -19,78 +18,117 @@ type adverse_event {
   other_attribution_description: String
   dose_limiting_toxicity: String
   unexpected_adverse_event: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
+  agent: agent @relation(name:"of_agent", direction:OUT)
   cases: [case] @relation(name:"had_adverse_event", direction:IN)
   next_adverse_event: adverse_event @relation(name:"next", direction:OUT)
   prior_adverse_event: adverse_event @relation(name:"next", direction:IN)
 }
 
+type agent {
+  medication: String
+  document_number: String
+  study_arms: [study_arm] @relation(name:"of_study_arm", direction:OUT)
+  agent_administrations: [agent_administration] @relation(name:"of_agent", direction:IN)
+  adverse_events: [adverse_event] @relation(name:"of_agent", direction:IN)
+}
+
+type agent_administration {
+  document_number: String
+  medication: String
+  route_of_administration: String
+  medication_lot_number: String
+  medication_vial_id: String
+  medication_actual_units_of_measure: String
+  medication_duration: Float
+  medication_duration_unit: String
+  medication_duration_original: Float
+  medication_duration_original_unit: String
+  medication_units_of_measure: String
+  medication_actual_dose: Float
+  medication_actual_dose_unit: String
+  medication_actual_dose_original: Float
+  medication_actual_dose_original_unit: String
+  phase: String
+  start_time: String
+  stop_time: String
+  dose_level: Float
+  dose_level_unit: String
+  dose_level_original: Float
+  dose_level_original_unit: String
+  dose_units_of_measure: String
+  date_of_missed_dose: String
+  medication_missed_dose: String
+  missed_dose_amount: Float
+  missed_dose_amount_unit: String
+  missed_dose_amount_original: Float
+  missed_dose_amount_original_unit: String
+  missed_dose_units_of_measure: String
+  medication_course_number: String
+  comment: String
+  agent: agent @relation(name:"of_agent", direction:OUT)
+  visit: visit @relation(name:"on_visit", direction:OUT)
+}
+
+type assay {
+  sample: sample @relation(name:"of_sample", direction:OUT)
+  files: [file] @relation(name:"of_assay", direction:IN)
+  images: [image] @relation(name:"of_assay", direction:IN)
+  schema_validation_placeholder: String
+}
+
 type biospecimen_source {
   biospecimen_repository_acronym: String
   biospecimen_repository_full_name: String
-  crdc_id: String
 }
 
 type canine_individual {
   canine_individual_id: String
-  crdc_id: String
   cases: [case] @relation(name:"represents", direction:IN)
 }
 
 type case {
-  case_record_id: String
+  case_id: String
   patient_id: String
   patient_first_name: String
-  crdc_id: String
   cohort: cohort @relation(name:"member_of", direction:OUT)
   study: study @relation(name:"member_of", direction:OUT)
   enrollment: enrollment @relation(name:"of_case", direction:IN)
   demographic: demographic @relation(name:"of_case", direction:IN)
-  diagnosis: diagnosis @relation(name:"of_case", direction:IN)
+  diagnoses: [diagnosis] @relation(name:"of_case", direction:IN)
   cycles: [cycle] @relation(name:"of_case", direction:IN)
+  follow_ups: [follow_up] @relation(name:"of_case", direction:IN)
   samples: [sample] @relation(name:"of_case", direction:IN)
   files: [file] @relation(name:"of_case", direction:IN)
   visits: [visit] @relation(name:"of_case", direction:IN)
   adverse_events: [adverse_event] @relation(name:"of_case", direction:IN)
   registrations: [registration] @relation(name:"of_case", direction:IN)
-  consent_group: consent_group @relation(name:"of_case", direction:OUT)
   study_arm: study_arm @relation(name:"of_study_arm", direction:OUT)
   adverse_event: adverse_event @relation(name:"had_adverse_event", direction:OUT)
+  off_study: off_study @relation(name:"went_off_study", direction:OUT)
+  off_treatment: off_treatment @relation(name:"went_off_treatment", direction:OUT)
   canine_individual: canine_individual @relation(name:"represents", direction:OUT)
 }
 
 type cohort {
-  cohort_record_id: String
   cohort_description: String
   cohort_dose: String
-  crdc_id: String
+  cohort_id: String
   cases: [case] @relation(name:"member_of", direction:IN)
   study_arm: study_arm @relation(name:"member_of", direction:OUT)
   study: study @relation(name:"member_of", direction:OUT)
 }
 
-type consent_group {
-  consent_group_record_id: String
-  consent_group_name: String
-  consent_group_number: Int
-  crdc_id: String
-  cases: [case] @relation(name:"of_case", direction:IN)
-  study: study @relation(name:"of_consent_group", direction:OUT)
-}
-
 type cycle {
-  cycle_record_id: String
   cycle_number: Int
   date_of_cycle_start: String
   date_of_cycle_end: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
   visits: [visit] @relation(name:"of_cycle", direction:IN)
 }
 
 type demographic {
-  demographic_record_id: String
+  demographic_id: String
   breed: String
   additional_breed_detail: String
   patient_age_at_enrollment: Float
@@ -104,12 +142,11 @@ type demographic {
   weight_original: Float
   weight_original_unit: String
   neutered_indicator: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
 }
 
 type diagnosis {
-  diagnosis_record_id: String
+  diagnosis_id: String
   disease_term: String
   primary_disease_site: String
   stage_of_disease: String
@@ -123,14 +160,12 @@ type diagnosis {
   follow_up_data: String
   concurrent_disease: String
   concurrent_disease_type: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
   files: [file] @relation(name:"from_diagnosis", direction:IN)
 }
 
 type disease_extent {
-  disease_extent_record_id: String
-  lesion_number: Int
+  lesion_number: String
   lesion_site: String
   lesion_description: String
   previously_irradiated: String
@@ -143,22 +178,20 @@ type disease_extent {
   longest_measurement_unit: String
   longest_measurement_original: Float
   longest_measurement_original_unit: String
-  evaluation_number: Int
+  evaluation_number: String
   evaluation_code: String
-  crdc_id: String
   visit: visit @relation(name:"on_visit", direction:OUT)
 }
 
 type enrollment {
-  enrollment_record_id: String
+  enrollment_id: String
+  date_of_registration: String
+  registering_institution: String
   initials: String
+  date_of_informed_consent: String
   site_short_name: String
   veterinary_medical_center: String
-  registering_institution: String
-  date_of_registration: String
-  date_of_informed_consent: String
   patient_subgroup: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
   prior_therapies: [prior_therapy] @relation(name:"at_enrollment", direction:IN)
   prior_surgeries: [prior_surgery] @relation(name:"at_enrollment", direction:IN)
@@ -170,16 +203,28 @@ type file {
   file_type: String
   file_description: String
   file_format: String
-  file_size: Int
+  file_size: Float
   md5sum: String
   file_status: String
   uuid: String
   file_location: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
   study: study @relation(name:"of_study", direction:OUT)
   sample: sample @relation(name:"of_sample", direction:OUT)
+  assay: assay @relation(name:"of_assay", direction:OUT)
   diagnosis: diagnosis @relation(name:"from_diagnosis", direction:OUT)
+}
+
+type follow_up {
+  document_number: String
+  date_of_last_contact: String
+  patient_status: String
+  explain_unknown_status: String
+  contact_type: String
+  treatment_since_last_contact: Boolean
+  physical_exam_performed: Boolean
+  physical_exam_changes: String
+  case: case @relation(name:"of_case", direction:OUT)
 }
 
 type human_relevance {
@@ -193,45 +238,82 @@ type human_relevance {
   study: study @relation(name:"of_study", direction:OUT)
 }
 
+type image {
+  assay: assay @relation(name:"of_assay", direction:OUT)
+  schema_validation_placeholder: String
+}
+
+type image_collection {
+  image_collection_name: String
+  image_type_included: String
+  image_collection_url: String
+  repository_name: String
+  collection_access: String
+  study: study @relation(name:"of_study", direction:OUT)
+}
+
+type lab_exam {
+  visit: visit @relation(name:"on_visit", direction:OUT)
+  schema_validation_placeholder: String
+}
+
+type off_study {
+  document_number: String
+  date_off_study: String
+  reason_off_study: String
+  date_of_disease_progression: String
+  date_off_treatment: String
+  best_resp_vet_tx_tp_secondary_response: String
+  date_last_medication_administration: String
+  best_resp_vet_tx_tp_best_response: String
+  date_of_best_response: String
+  case: case @relation(name:"went_off_study", direction:IN)
+}
+
+type off_treatment {
+  document_number: String
+  date_off_treatment: String
+  reason_off_treatment: String
+  date_of_disease_progression: String
+  best_resp_vet_tx_tp_secondary_response: String
+  date_last_medication_administration: String
+  best_resp_vet_tx_tp_best_response: String
+  date_of_best_response: String
+  case: case @relation(name:"went_off_treatment", direction:IN)
+}
+
 type physical_exam {
-  physical_exam_record_id: String
   date_of_examination: String
   day_in_cycle: Int
   body_system: String
   pe_finding: String
   pe_comment: String
   phase_pe: String
-  assessment_timepoint: String
-  crdc_id: String
+  assessment_timepoint: Int
   enrollment: enrollment @relation(name:"at_enrollment", direction:OUT)
   visit: visit @relation(name:"on_visit", direction:OUT)
 }
 
 type principal_investigator {
-  person_record_id: String
   pi_first_name: String
   pi_last_name: String
   pi_middle_initial: String
-  crdc_id: String
   studies: [study] @relation(name:"of_study", direction:OUT)
 }
 
 type prior_surgery {
-  prior_surgery_record_id: String
   date_of_surgery: String
   procedure: String
   anatomical_site_of_surgery: String
   surgical_finding: String
   residual_disease: String
   therapeutic_indicator: String
-  crdc_id: String
   enrollment: enrollment @relation(name:"at_enrollment", direction:OUT)
   next_prior_surgery: prior_surgery @relation(name:"next", direction:OUT)
   prior_prior_surgery: prior_surgery @relation(name:"next", direction:IN)
 }
 
 type prior_therapy {
-  prior_therapy_record_id: String
   date_of_first_dose: String
   date_of_last_dose: String
   agent_name: String
@@ -261,7 +343,6 @@ type prior_therapy {
   date_of_last_dose_any_therapy: String
   treatment_performed_at_site: Boolean
   treatment_performed_in_minimal_residual: Boolean
-  crdc_id: String
   enrollment: enrollment @relation(name:"at_enrollment", direction:OUT)
   next_prior_therapy: prior_therapy @relation(name:"next", direction:OUT)
   prior_prior_therapy: prior_therapy @relation(name:"next", direction:IN)
@@ -274,7 +355,6 @@ type program {
   program_full_description: String
   program_external_url: String
   program_sort_order: Int
-  crdc_id: String
   studies: [study] @relation(name:"member_of", direction:IN)
 }
 
@@ -285,14 +365,12 @@ type publication {
   journal_citation: String
   digital_object_id: String
   pubmed_id: Float
-  crdc_id: String
   study: study @relation(name:"of_study", direction:OUT)
 }
 
 type registration {
   registration_origin: String
-  registration_record_id: String
-  crdc_id: String
+  registration_id: String
   cases: [case] @relation(name:"of_case", direction:OUT)
 }
 
@@ -324,9 +402,9 @@ type sample {
   percentage_tumor: String
   sample_preservation: String
   comment: String
-  crdc_id: String
   case: case @relation(name:"of_case", direction:OUT)
   visit: visit @relation(name:"on_visit", direction:OUT)
+  assays: [assay] @relation(name:"of_sample", direction:IN)
   files: [file] @relation(name:"of_sample", direction:IN)
   next_sample: sample @relation(name:"next", direction:OUT)
   prior_sample: sample @relation(name:"next", direction:IN)
@@ -342,7 +420,6 @@ type study {
   dates_of_conduct: String
   accession_id: String
   study_disposition: String
-  crdc_id: String
   study_arms: [study_arm] @relation(name:"member_of", direction:IN)
   program: program @relation(name:"member_of", direction:OUT)
   cases: [case] @relation(name:"member_of", direction:IN)
@@ -351,17 +428,18 @@ type study {
   study_sites: [study_site] @relation(name:"of_study", direction:IN)
   principal_investigators: [principal_investigator] @relation(name:"of_study", direction:IN)
   files: [file] @relation(name:"of_study", direction:IN)
+  image_collections: [image_collection] @relation(name:"of_study", direction:IN)
   publications: [publication] @relation(name:"of_study", direction:IN)
-  NONE: [consent_group] @relation(name:"of_consent_group", direction:IN)
 }
 
 type study_arm {
-  arm_id: String
   arm: String
+  ctep_treatment_assignment_code: String
   arm_description: String
-  crdc_id: String
+  arm_id: String
   cohorts: [cohort] @relation(name:"member_of", direction:IN)
   study: study @relation(name:"member_of", direction:OUT)
+  agents: [agent] @relation(name:"of_study_arm", direction:IN)
   cases: [case] @relation(name:"of_study_arm", direction:IN)
 }
 
@@ -369,19 +447,19 @@ type study_site {
   site_short_name: String
   veterinary_medical_center: String
   registering_institution: String
-  crdc_id: String
   studies: [study] @relation(name:"of_study", direction:OUT)
 }
 
 type visit {
-  visit_record_id: String
   visit_date: String
-  visit_number: Int
-  crdc_id: String
+  visit_number: String
+  visit_id: String
   case: case @relation(name:"of_case", direction:OUT)
   cycle: cycle @relation(name:"of_cycle", direction:OUT)
+  agent_administrations: [agent_administration] @relation(name:"on_visit", direction:IN)
   samples: [sample] @relation(name:"on_visit", direction:IN)
   physical_exams: [physical_exam] @relation(name:"on_visit", direction:IN)
+  lab_exams: [lab_exam] @relation(name:"on_visit", direction:IN)
   disease_extents: [disease_extent] @relation(name:"on_visit", direction:IN)
   vital_signs: [vital_signs] @relation(name:"on_visit", direction:IN)
   next_visit: visit @relation(name:"next", direction:OUT)
@@ -389,30 +467,28 @@ type visit {
 }
 
 type vital_signs {
-  vital_signs_record_id: String
   date_of_vital_signs: String
   body_temperature: Float
   body_temperature_unit: String
   body_temperature_original: Float
   body_temperature_original_unit: String
+  pulse: Int
+  pulse_unit: String
+  pulse_original: Int
+  pulse_original_unit: String
   respiration_rate: Int
   respiration_rate_unit: String
   respiration_rate_original: Int
   respiration_rate_original_unit: String
   respiration_pattern: String
-  pulse: Int
-  pulse_unit: String
-  pulse_original: Int
-  pulse_original_unit: String
-  pulse_ox: Float
-  pulse_ox_unit: String
-  pulse_ox_original: Float
-  pulse_ox_original_unit: String
   systolic_bp: Int
   systolic_bp_unit: String
   systolic_bp_original: Int
   systolic_bp_original_unit: String
-  ecg: String
+  pulse_ox: Float
+  pulse_ox_unit: String
+  pulse_ox_original: Float
+  pulse_ox_original_unit: String
   patient_weight: Float
   patient_weight_unit: String
   patient_weight_original: Float
@@ -422,8 +498,9 @@ type vital_signs {
   body_surface_area_original: Float
   body_surface_area_original_unit: String
   modified_ecog: String
-  assessment_timepoint: String
-  crdc_id: String
+  ecg: String
+  assessment_timepoint: Int
+  phase: String
   visit: visit @relation(name:"on_visit", direction:OUT)
 }
 
@@ -443,7 +520,7 @@ type CaseDetail {
     arm: String
     ctep_treatment_assignment_code: String
     cohort_description: String
-    case_record_id: String
+    case_id: String
     patient_id: String
     patient_first_name: String
     breed: String
@@ -504,7 +581,7 @@ type FileOverview2 {
 }
 
 type CaseOverview {
-    case_record_id: String
+    case_id: String
     program: String
     study_code: String
     study_type: String
@@ -526,7 +603,7 @@ type CaseOverview {
 
 
 type FilesOfCase{
-    case_record_id: String
+    case_id: String
     parent:String
     file_name: String
     file_type: String
@@ -556,7 +633,7 @@ type FileDetail {
     arm: String
     cohort_description: String
     cohort_dose: String
-    case_record_id: String
+    case_id: String
     breed: String
     weight: Float
     sex: String
@@ -618,7 +695,7 @@ type FileInList {
     file_description: String
     file_format: String
     file_size: Float
-    case_record_id: String
+    case_id: String
     breed: String
     diagnosis: String
     study_code: String
@@ -684,7 +761,7 @@ type FileOverview {
     file_description: String
     file_format: String
     file_size: Float
-    case_record_id: String
+    case_id: String
     breed: String
     diagnosis: String
     study_code: String
@@ -726,7 +803,7 @@ type FileOverview {
 
 type SampleOverview {
     sample_id: String
-    case_record_id: String
+    case_id: String
     breed: String
     diagnosis: String
     sample_site: String
@@ -764,7 +841,7 @@ type SampleOverview {
 }
 
 type CaseOverview2 {
-    case_record_id: String
+    case_id: String
     study_code: String
     study_type: String
     cohort: String
@@ -800,7 +877,7 @@ type GroupCount {
 
 type MultiStudyCases {
     individualId: String
-    caseRecordIds: [String]
+    caseIds: [String]
     sampleIds: [String]
     fileIds: [String]
     studyFileIds: [String]
@@ -838,12 +915,12 @@ type CycleNodeData {
     cycle_number: Int
     date_of_cycle_end: String
     crf_id: String
-    case_record_id: String
+    case_id: String
     date_of_cycle_start: String
 }
 
 type VisitNodeData {
-    case_record_id: String
+    case_id: String
     visit_date: String
     visit_number: Int
     visit_id: String
@@ -861,7 +938,7 @@ type FollowUpNodeData {
 }
 
 type AdverseEventNodeData {
-    case_record_id: String
+    case_id: String
     day_in_cycle: Int
     dose_limiting_toxicity: String
     unexpected_adverse_event: String
@@ -936,7 +1013,7 @@ type PriorTherapyNodeData {
 }
 
 type PriorSurgeryNodeData {
-    case_record_id: String
+    case_id: String
     date_of_surgery: String
     procedure: String
     anatomical_site_of_surgery: String
@@ -946,7 +1023,7 @@ type PriorSurgeryNodeData {
 }
 
 type PhysicalExamNodeData {
-    case_record_id: String
+    case_id: String
     date_of_examination: String
     day_in_cycle: Int
     body_system: String
@@ -962,7 +1039,7 @@ type AgentNodeData {
 }
 
 type DiseaseExtentNodeData {
-    case_record_id: String
+    case_id: String
     lesion_number: Int
     lesion_site: String
     lesion_description: String
@@ -1012,7 +1089,7 @@ type VitalSignsNodeData {
     body_surface_area_original_unit: String
     patient_weight: Float
     patient_weight_unit: String
-    case_record_id: String
+    case_id: String
     time_of_observation: String
     pulse_original_unit: String
     respiration_rate_original_unit: String
@@ -1081,7 +1158,7 @@ type QueryType {
     numberOfPrograms: Int @cypher(statement: "MATCH (n:program) RETURN count (n)")
     numberOfAliquots: Int @cypher(statement: "MATCH (n:aliquot) return count(n)")
     volumeOfData: Float @cypher(statement: "MATCH (f:file) WITH DISTINCT f return sum(f.file_size)")
-    volumeOfDataOfCase(case_record_id: String!): Float @cypher(statement: "MATCH (c:case{case_record_id: $case_record_id})-->(s:study) WITH s OPTIONAL MATCH (s)<--(f:file) WITH SUM(f.file_size) AS study_file_size OPTIONAL MATCH (c:case{case_record_id: $case_record_id})<-[*]-(f:file) with DISTINCT f, study_file_size RETURN SUM(f.file_size) + study_file_size")
+    volumeOfDataOfCase(case_id: String!): Float @cypher(statement: "MATCH (c:case{case_id: $case_id})-->(s:study) WITH s OPTIONAL MATCH (s)<--(f:file) WITH SUM(f.file_size) AS study_file_size OPTIONAL MATCH (c:case{case_id: $case_id})<-[*]-(f:file) with DISTINCT f, study_file_size RETURN SUM(f.file_size) + study_file_size")
     volumeOfDataOfProgram(program_id: String!): Float @cypher(statement: "MATCH (f:file)-[*]->(:program {program_acronym: $program_id}) WITH DISTINCT f return sum(f.file_size)")
     volumeOfDataOfStudy(study_code: String!): Float @cypher(statement: "MATCH (f:file)-[*]->(:study {clinical_study_designation: $study_code}) WITH DISTINCT f return sum(f.file_size)")
 
@@ -1092,19 +1169,19 @@ type QueryType {
     fileCountOfStudyFiles(study_code: String!): Int @cypher(statement: "MATCH (f:file)-->(sd:study) WHERE sd.clinical_study_designation = $study_code OR sd.accession_id = $study_code return count(distinct(f))")
     aliquotCountOfStudy(study_code: String!): Int @cypher(statement: "MATCH (a:aliquot)-[*]->(sd:study) WHERE sd.clinical_study_designation = $study_code OR sd.accession_id = $study_code  return count(DISTINCT(a))")
     caseCountOfStudy(study_code: String!): Int @cypher(statement: "MATCH (c:case)-[*]->(sd:study) WHERE sd.clinical_study_designation = $study_code OR sd.accession_id = $study_code return count(distinct(c))")
-    fileCountOfCase(case_record_id: String!): Int @cypher(statement: "MATCH (f:file)-[*]->(c:case {case_record_id: $case_record_id}) return count(DISTINCT(f))")
-    studyFileCountOfCase(case_record_id: String!): Int @cypher(statement: "MATCH (c:case {case_record_id: $case_record_id}) OPTIONAL MATCH (c)-[:member_of]->(s:study) OPTIONAL MATCH (s)<--(f:file) return count(DISTINCT(f))")
-    aliquotCountOfCase(case_record_id: String!): Int @cypher(statement: "MATCH (a:aliquot)-[*]->(c:case {case_record_id: $case_record_id}) return count(DISTINCT(a))")
+    fileCountOfCase(case_id: String!): Int @cypher(statement: "MATCH (f:file)-[*]->(c:case {case_id: $case_id}) return count(DISTINCT(f))")
+    studyFileCountOfCase(case_id: String!): Int @cypher(statement: "MATCH (c:case {case_id: $case_id}) OPTIONAL MATCH (c)-[:member_of]->(s:study) OPTIONAL MATCH (s)<--(f:file) return count(DISTINCT(f))")
+    aliquotCountOfCase(case_id: String!): Int @cypher(statement: "MATCH (a:aliquot)-[*]->(c:case {case_id: $case_id}) return count(DISTINCT(a))")
     sampleCountOfProgram(program_id: String!): Int @cypher(statement: "MATCH (s:sample)-[*]->(:program {program_acronym: $program_id}) return count(DISTINCT(s))")
     fileCountOfProgram(program_id: String!): Int @cypher(statement: "MATCH (f:file)-[*]->(:program {program_acronym: $program_id}) return count(DISTINCT(f))")
     studyFileCountOfProgram(program_id: String!): Int @cypher(statement: "MATCH (s:study)-[*]->(:program {program_acronym: $program_id}) OPTIONAL MATCH (s) <-- (f:file) return count(DISTINCT(f))")
     aliquotCountOfProgram(program_id: String!): Int @cypher(statement: "MATCH (a:aliquot)-[*]->(:program {program_acronym: $program_id}) return count(DISTINCT(a))")
     studyCountOfProgram(program_id: String!): Int @cypher(statement: "MATCH (s:study)-[*]->(:program {program_acronym: $program_id}) WHERE s.study_disposition = 'Unrestricted' return count(DISTINCT(s))")
     caseCountOfProgram(program_id: String!): Int @cypher(statement: "MATCH (c:case)-[*]->(:program {program_acronym: $program_id}) return count(DISTINCT(c))")
-    sampleCountOfCase(case_record_id: String!): Int @cypher(statement: "MATCH (c:case {case_record_id: $case_record_id})<-[*]-(s:sample) RETURN count(distinct(s))")
+    sampleCountOfCase(case_id: String!): Int @cypher(statement: "MATCH (c:case {case_id: $case_id})<-[*]-(s:sample) RETURN count(distinct(s))")
 
     programCountOfStudy(study_code: String!): Int @cypher(statement: "MATCH (s:study {clinical_study_designation: $study_code}) OPTIONAL MATCH (s)-[:member_of]->(p: program)  return count(DISTINCT(p))")
-    programsCountOfCase(case_record_id: String!): Int @cypher(statement: "MATCH (c:case {case_record_id: $case_record_id}) OPTIONAL MATCH (c)-[:member_of]->(s:study) OPTIONAL MATCH (s)-[:member_of]->(p:program) return count(DISTINCT(p))")
+    programsCountOfCase(case_id: String!): Int @cypher(statement: "MATCH (c:case {case_id: $case_id}) OPTIONAL MATCH (c)-[:member_of]->(s:study) OPTIONAL MATCH (s)-[:member_of]->(p:program) return count(DISTINCT(p))")
 
     filesInList(uuids: [String], order_by: String = ""): [FileInList] @cypher(statement: """
     MATCH (f:file)
@@ -1127,7 +1204,7 @@ type QueryType {
     f.file_description AS file_description,
     f.file_format AS file_format,
     f.file_size AS file_size,
-    c.case_record_id AS case_record_id,
+    c.case_id AS case_id,
     demo.breed AS breed,
     diag.disease_term AS diagnosis,
     CASE WHEN s.clinical_study_designation IS NULL
@@ -1169,7 +1246,7 @@ type QueryType {
     diag.concurrent_disease_type AS concurrent_disease_type,
     co.cohort_description AS cohort_description,
     a.arm AS arm,
-    collect(DISTINCT o.case_record_id) AS other_cases,
+    collect(DISTINCT o.case_id) AS other_cases,
     'drs://nci-crdc.datacommons.io/dg.4DFC/' AS drs_prefix,
     f.file_location AS file_location,
     c.patient_id AS patient_id,
@@ -1192,7 +1269,7 @@ type QueryType {
     file_description: file_description,
     file_format: file_format,
     file_size: file_size,
-    case_record_id: case_record_id,
+    case_id: case_id,
     breed: breed,
     diagnosis: diagnosis,
     study_code: study_code,
@@ -1257,7 +1334,7 @@ type QueryType {
     WHEN 'file_description' THEN file_description
     WHEN 'file_format' THEN file_format
     WHEN 'file_size' THEN file_size
-    WHEN 'case_record_id' THEN case_record_id
+    WHEN 'case_id' THEN case_id
     WHEN 'breed' THEN breed
     WHEN 'diagnosis' THEN diagnosis
     WHEN 'study_code' THEN study_code
@@ -1290,7 +1367,7 @@ type QueryType {
     f.file_description AS file_description,
     f.file_format AS file_format,
     f.file_size AS file_size,
-    c.case_record_id AS case_record_id,
+    c.case_id AS case_id,
     demo.breed AS breed,
     diag.disease_term AS diagnosis,
     CASE WHEN s.clinical_study_designation IS NULL
@@ -1332,7 +1409,7 @@ type QueryType {
     diag.concurrent_disease_type AS concurrent_disease_type,
     co.cohort_description AS cohort_description,
     a.arm AS arm,
-    collect(DISTINCT o.case_record_id) AS other_cases,
+    collect(DISTINCT o.case_id) AS other_cases,
     'drs://nci-crdc.datacommons.io/dg.4DFC/' AS drs_prefix,
     f.file_location AS file_location,
     c.patient_id AS patient_id,
@@ -1355,7 +1432,7 @@ type QueryType {
     file_description: file_description,
     file_format: file_format,
     file_size: file_size,
-    case_record_id: case_record_id,
+    case_id: case_id,
     breed: breed,
     diagnosis: diagnosis,
     study_code: study_code,
@@ -1420,7 +1497,7 @@ type QueryType {
     WHEN 'file_description' THEN file_description
     WHEN 'file_format' THEN file_format
     WHEN 'file_size' THEN file_size
-    WHEN 'case_record_id' THEN case_record_id
+    WHEN 'case_id' THEN case_id
     WHEN 'breed' THEN breed
     WHEN 'diagnosis' THEN diagnosis
     WHEN 'study_code' THEN study_code
@@ -1510,8 +1587,8 @@ type QueryType {
     ORDER BY s.clinical_study_designation
     """, passThrough: true)
 
-    filesOfCase(case_record_id: String!): [FilesOfCase] @cypher(statement: """
-    MATCH (f:file)-[*]->(c:case{case_record_id: $case_record_id})
+    filesOfCase(case_id: String!): [FilesOfCase] @cypher(statement: """
+    MATCH (f:file)-[*]->(c:case{case_id: $case_id})
     WITH DISTINCT(f) AS f
     MATCH (f)-->(parent)
     RETURN{
@@ -1525,16 +1602,16 @@ type QueryType {
     uuid: f.uuid,
     file_location: f.file_location,
     parent: head(labels(parent)),
-    case_record_id: $case_record_id
+    case_id: $case_id
     }
     """, passThrough: true)
 
-    filesOfCases(case_record_ids: [String!]!): [FilesOfCase] @cypher(statement: """
+    filesOfCases(case_ids: [String!]!): [FilesOfCase] @cypher(statement: """
     MATCH (f:file)-[*]->(c:case)
     WITH
     DISTINCT(f) AS f,
     c MATCH (f)-->(parent)
-    WHERE c.case_record_id IN $case_record_ids
+    WHERE c.case_id IN $case_ids
     RETURN{
     file_status: f.file_status,
     file_name: f.file_name,
@@ -1546,12 +1623,12 @@ type QueryType {
     uuid: f.uuid,
     file_location: f.file_location,
     parent: head(labels(parent)),
-    case_record_id: c.case_record_id
+    case_id: c.case_id
     }
     """, passThrough: true)
 
-    multiStudyCases(case_record_id: String): MultiStudyCases @cypher(statement: """
-    MATCH (:case {case_record_id: $case_record_id})-->(i:canine_individual)
+    multiStudyCases(case_id: String): MultiStudyCases @cypher(statement: """
+    MATCH (:case {case_id: $case_id})-->(i:canine_individual)
     MATCH (i)<--(c:case)
     OPTIONAL MATCH (c)<--(samp:sample)
     OPTIONAL MATCH (c)<-[*]-(f:file)
@@ -1560,15 +1637,15 @@ type QueryType {
     WITH i, c, f, samp, sf
     RETURN{
     individualId: i.canine_individual_id,
-    caseRecordIds: collect(DISTINCT c.case_record_id),
+    caseIds: collect(DISTINCT c.case_id),
     sampleIds: collect(DISTINCT samp.sample_id),
     fileIds: collect(DISTINCT f.uuid),
     studyFileIds: collect(DISTINCT sf.uuid)
     }
     """, passThrough: true)
 
-    caseDetail(case_record_id: String): CaseDetail @cypher(statement: """
-    MATCH (c:case {case_record_id: $case_record_id})-->(s:study)-->(p:program)
+    caseDetail(case_id: String): CaseDetail @cypher(statement: """
+    MATCH (c:case {case_id: $case_id})-->(s:study)-->(p:program)
     OPTIONAL MATCH (c)-->(co:cohort)-->(a:study_arm)
     OPTIONAL MATCH (c)<--(demo:demographic)
     OPTIONAL MATCH (c)<--(diag:diagnosis)
@@ -1580,7 +1657,7 @@ type QueryType {
     arm: a.arm,
     ctep_treatment_assignment_code: a.ctep_treatment_assignment_code,
     cohort_description: co.cohort_description,
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     patient_id: c.patient_id,
     patient_first_name: c.patient_first_name,
     breed: demo.breed,
@@ -1644,7 +1721,7 @@ type QueryType {
     OPTIONAL MATCH (samp:sample)-[*]->(c)
     WITH DISTINCT c AS c, p, s, demo, diag, f, samp, prt
     RETURN{
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     study_code: s.clinical_study_designation,
     program: p.program_acronym,
     study_type: s.clinical_study_type,
@@ -1665,16 +1742,16 @@ type QueryType {
     }
     """, passThrough: true)
 
-    casesInList(case_record_ids: [String!]!): [CaseOverview] @cypher(statement: """
+    casesInList(case_ids: [String!]!): [CaseOverview] @cypher(statement: """
     MATCH
     (p:program)<-[*]-(s:study)<-[*]-(c:case)<--(demo:demographic),
     (c)<--(diag:diagnosis)
-    WHERE c.case_record_id IN $case_record_ids
+    WHERE c.case_id IN $case_ids
     OPTIONAL MATCH (f:file)-[*]->(c)
     OPTIONAL MATCH (samp:sample)-[*]->(c)
     WITH DISTINCT c AS c, p, s, demo, diag, f, samp
     RETURN{
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     study_code: s.clinical_study_designation,
     program: p.program_acronym,
     study_type: s.clinical_study_type,
@@ -1714,8 +1791,8 @@ type QueryType {
     RETURN DISTINCT(c)
     """)
 
-    samplesByCaseRecordId(case_record_id: String!): [sample] @cypher(statement: """
-    MATCH (c:case {case_record_id: $case_record_id})<-[*]-(s:sample)
+    samplesByCaseId(case_id: String!): [sample] @cypher(statement: """
+    MATCH (c:case {case_id: $case_id})<-[*]-(s:sample)
     RETURN s
     """)
 
@@ -1752,14 +1829,14 @@ type QueryType {
     OPTIONAL MATCH (f)-->(samp:sample)
     WITH DISTINCT (f) AS f, s, c, co, arm, demo, diag, v, samp,
     f.file_type as file_type,
-    c.case_record_id as case_record_id
+    c.case_id as case_id
     RETURN{
     clinical_study_designation: s.clinical_study_designation,
     clinical_study_name: s.clinical_study_name,
     arm: arm.arm,
     cohort_description: co.cohort_description,
     cohort_dose: co.cohort_dose,
-    case_record_id: case_record_id,
+    case_id: case_id,
     breed: demo.breed,
     weight: demo.weight,
     sex: demo.sex,
@@ -1797,7 +1874,7 @@ type QueryType {
     size: f.file_size,
     url: f.file_location
     }
-    ORDER BY file_type, case_record_id
+    ORDER BY file_type, case_id
     """, passThrough: true)
 
     "For IndexD to replace manifest"
@@ -1866,9 +1943,9 @@ type QueryType {
     ELSE file_name END DESC
     """, passThrough: true)
 
-    unifiedViewData(case_record_ids: [String] = [""]): UnifiedCounts @cypher(statement: """
+    unifiedViewData(case_ids: [String] = [""]): UnifiedCounts @cypher(statement: """
     MATCH (c:case)
-    WHERE ($case_record_ids = [""] OR $case_record_ids IS NULL OR c.case_record_id IN $case_record_ids)
+    WHERE ($case_ids = [""] OR $case_ids IS NULL OR c.case_id IN $case_ids)
     OPTIONAL MATCH (s:study)<--(c)
     OPTIONAL MATCH (f:file)-[*]->(c)
     OPTIONAL MATCH (samp:sample)-->(c)
@@ -1986,7 +2063,7 @@ type QueryType {
     OPTIONAL MATCH (v)<-[:on_visit]-(le:lab_exam)
     RETURN {
     agent: COUNT(DISTINCT a),
-    cycle: COUNT(DISTINCT cy.case_record_id),
+    cycle: COUNT(DISTINCT cy.case_id),
     visit: COUNT(DISTINCT left(v.visit_id, 13)),
     follow_up: COUNT(DISTINCT fu),
     adverse_event: COUNT(DISTINCT endNode(aeoc)),
@@ -1995,9 +2072,9 @@ type QueryType {
     prior_therapy: COUNT(DISTINCT pt),
     prior_surgery: COUNT(DISTINCT ps),
     agent_administration: COUNT(DISTINCT aa),
-    physical_exam: COUNT(DISTINCT pe.case_record_id),
-    vital_signs: COUNT(DISTINCT vs.case_record_id),
-    disease_extent: COUNT(DISTINCT de.case_record_id),
+    physical_exam: COUNT(DISTINCT pe.case_id),
+    vital_signs: COUNT(DISTINCT vs.case_id),
+    disease_extent: COUNT(DISTINCT de.case_id),
     lab_exam: COUNT(DISTINCT le)
     }
     """, passThrough: true)
@@ -2045,12 +2122,12 @@ type QueryType {
     MATCH (c)<-[*1..2]-(v:visit)
     WITH DISTINCT v, c
     RETURN {
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     visit_date: v.visit_date,
     visit_number: v.visit_number,
     visit_id: v.visit_id
     }
-    ORDER BY c.case_record_id
+    ORDER BY c.case_id
     """, passThrough: true)
 
     followUpNodeData(study_code: String!): [FollowUpNodeData] @cypher(statement: """
@@ -2068,7 +2145,7 @@ type QueryType {
     MATCH (c)<-[:of_case]-(ae:adverse_event)
     WITH DISTINCT ae, c
     RETURN {
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     day_in_cycle: ae.day_in_cycle,
     date_of_onset: ae.date_of_onset,
     existing_adverse_event: ae.existing_adverse_event,
@@ -2089,7 +2166,7 @@ type QueryType {
     dose_limiting_toxicity: ae.dose_limiting_toxicity,
     unexpected_adverse_event: ae.unexpected_adverse_event
     }
-    ORDER BY c.case_record_id
+    ORDER BY c.case_id
     """, passThrough: true)
 
     offTreatmentNodeData(study_code: String!): [OffTreatmentNodeData] @cypher(statement: """
@@ -2125,7 +2202,7 @@ type QueryType {
     MATCH (e)<-[:at_enrollment]-(ps:prior_surgery)
     WITH DISTINCT c, ps
     RETURN {
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     date_of_surgery: ps.date_of_surgery,
     procedure: ps.procedure,
     anatomical_site_of_surgery: ps.anatomical_site_of_surgery,
@@ -2133,7 +2210,7 @@ type QueryType {
     residual_disease: ps.residual_disease,
     therapeutic_indicator: ps.therapeutic_indicator
     }
-    ORDER BY c.case_record_id
+    ORDER BY c.case_id
     """, passThrough: true)
 
     agentAdministrationNodeData(study_code: String!): [AgentAdministrationNodeData] @cypher(statement: """
@@ -2153,7 +2230,7 @@ type QueryType {
     MATCH (v)<-[:on_visit]-(pe:physical_exam)
     WITH DISTINCT pe, c
     RETURN {
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     date_of_examination: pe.date_of_examination,
     day_in_cycle: pe.day_in_cycle,
     body_system: pe.body_system,
@@ -2162,7 +2239,7 @@ type QueryType {
     phase_pe: pe.phase_pe,
     assessment_timepoint: pe.assessment_timepoint
     }
-    ORDER BY c.case_record_id
+    ORDER BY c.case_id
     """, passThrough: true)
 
     vitalSignsNodeData(study_code: String!): [VitalSignsNodeData] @cypher(statement: """
@@ -2182,7 +2259,7 @@ type QueryType {
     MATCH (v)<-[:on_visit]-(de:disease_extent)
     WITH DISTINCT de, c
     RETURN {
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     lesion_number: de.lesion_number,
     lesion_site: de.lesion_site,
     lesion_description: de.lesion_description,
@@ -2196,7 +2273,7 @@ type QueryType {
     evaluation_number: de.evaluation_number,
     evaluation_code: de.evaluation_code
     }
-    ORDER BY c.case_record_id
+    ORDER BY c.case_id
     """, passThrough: true)
 
     # labExamNodeData(study_code: String!): [LabExamNodeData] @cypher(statement: """
@@ -2215,12 +2292,12 @@ type QueryType {
     MATCH (c)<-[:of_case]-(e:enrollment)
     MATCH (e)<-[:at_enrollment]-(ps:prior_surgery)
     WITH DISTINCT c, ps
-    ORDER BY c.case_record_id
+    ORDER BY c.case_id
     RETURN
     {
       case_count: COUNT(DISTINCT c),
       prior_surgeries: collect({
-        case_record_id: c.case_record_id,
+        case_id: c.case_id,
         date_of_surgery: ps.date_of_surgery,
         procedure: ps.procedure,
         anatomical_site_of_surgery: ps.anatomical_site_of_surgery,

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -14,7 +14,7 @@ type CaseDetail {
     arm: String
     ctep_treatment_assignment_code: String
     cohort_description: String
-    case_record_id: String
+    case_id: String
     patient_id: String
     patient_first_name: String
     breed: String
@@ -75,7 +75,7 @@ type FileOverview2 {
 }
 
 type CaseOverview {
-    case_record_id: String
+    case_id: String
     program: String
     study_code: String
     study_type: String
@@ -97,7 +97,7 @@ type CaseOverview {
 
 
 type FilesOfCase{
-    case_record_id: String
+    case_id: String
     parent:String
     file_name: String
     file_type: String
@@ -127,7 +127,7 @@ type FileDetail {
     arm: String
     cohort_description: String
     cohort_dose: String
-    case_record_id: String
+    case_id: String
     breed: String
     weight: Float
     sex: String
@@ -189,7 +189,7 @@ type FileInList {
     file_description: String
     file_format: String
     file_size: Float
-    case_record_id: String
+    case_id: String
     breed: String
     diagnosis: String
     study_code: String
@@ -255,7 +255,7 @@ type FileOverview {
     file_description: String
     file_format: String
     file_size: Float
-    case_record_id: String
+    case_id: String
     breed: String
     diagnosis: String
     study_code: String
@@ -297,7 +297,7 @@ type FileOverview {
 
 type SampleOverview {
     sample_id: String
-    case_record_id: String
+    case_id: String
     breed: String
     diagnosis: String
     sample_site: String
@@ -335,7 +335,7 @@ type SampleOverview {
 }
 
 type CaseOverview2 {
-    case_record_id: String
+    case_id: String
     study_code: String
     study_type: String
     cohort: String
@@ -371,7 +371,7 @@ type GroupCount {
 
 type MultiStudyCases {
     individualId: String
-    caseRecordIds: [String]
+    caseIds: [String]
     sampleIds: [String]
     fileIds: [String]
     studyFileIds: [String]
@@ -409,12 +409,12 @@ type CycleNodeData {
     cycle_number: Int
     date_of_cycle_end: String
     crf_id: String
-    case_record_id: String
+    case_id: String
     date_of_cycle_start: String
 }
 
 type VisitNodeData {
-    case_record_id: String
+    case_id: String
     visit_date: String
     visit_number: Int
     visit_id: String
@@ -432,7 +432,7 @@ type FollowUpNodeData {
 }
 
 type AdverseEventNodeData {
-    case_record_id: String
+    case_id: String
     day_in_cycle: Int
     dose_limiting_toxicity: String
     unexpected_adverse_event: String
@@ -507,7 +507,7 @@ type PriorTherapyNodeData {
 }
 
 type PriorSurgeryNodeData {
-    case_record_id: String
+    case_id: String
     date_of_surgery: String
     procedure: String
     anatomical_site_of_surgery: String
@@ -517,7 +517,7 @@ type PriorSurgeryNodeData {
 }
 
 type PhysicalExamNodeData {
-    case_record_id: String
+    case_id: String
     date_of_examination: String
     day_in_cycle: Int
     body_system: String
@@ -533,7 +533,7 @@ type AgentNodeData {
 }
 
 type DiseaseExtentNodeData {
-    case_record_id: String
+    case_id: String
     lesion_number: Int
     lesion_site: String
     lesion_description: String
@@ -583,7 +583,7 @@ type VitalSignsNodeData {
     body_surface_area_original_unit: String
     patient_weight: Float
     patient_weight_unit: String
-    case_record_id: String
+    case_id: String
     time_of_observation: String
     pulse_original_unit: String
     respiration_rate_original_unit: String
@@ -652,7 +652,7 @@ type QueryType {
     numberOfPrograms: Int @cypher(statement: "MATCH (n:program) RETURN count (n)")
     numberOfAliquots: Int @cypher(statement: "MATCH (n:aliquot) return count(n)")
     volumeOfData: Float @cypher(statement: "MATCH (f:file) WITH DISTINCT f return sum(f.file_size)")
-    volumeOfDataOfCase(case_record_id: String!): Float @cypher(statement: "MATCH (c:case{case_record_id: $case_record_id})-->(s:study) WITH s OPTIONAL MATCH (s)<--(f:file) WITH SUM(f.file_size) AS study_file_size OPTIONAL MATCH (c:case{case_record_id: $case_record_id})<-[*]-(f:file) with DISTINCT f, study_file_size RETURN SUM(f.file_size) + study_file_size")
+    volumeOfDataOfCase(case_id: String!): Float @cypher(statement: "MATCH (c:case{case_id: $case_id})-->(s:study) WITH s OPTIONAL MATCH (s)<--(f:file) WITH SUM(f.file_size) AS study_file_size OPTIONAL MATCH (c:case{case_id: $case_id})<-[*]-(f:file) with DISTINCT f, study_file_size RETURN SUM(f.file_size) + study_file_size")
     volumeOfDataOfProgram(program_id: String!): Float @cypher(statement: "MATCH (f:file)-[*]->(:program {program_acronym: $program_id}) WITH DISTINCT f return sum(f.file_size)")
     volumeOfDataOfStudy(study_code: String!): Float @cypher(statement: "MATCH (f:file)-[*]->(:study {clinical_study_designation: $study_code}) WITH DISTINCT f return sum(f.file_size)")
 
@@ -663,19 +663,19 @@ type QueryType {
     fileCountOfStudyFiles(study_code: String!): Int @cypher(statement: "MATCH (f:file)-->(sd:study) WHERE sd.clinical_study_designation = $study_code OR sd.accession_id = $study_code return count(distinct(f))")
     aliquotCountOfStudy(study_code: String!): Int @cypher(statement: "MATCH (a:aliquot)-[*]->(sd:study) WHERE sd.clinical_study_designation = $study_code OR sd.accession_id = $study_code  return count(DISTINCT(a))")
     caseCountOfStudy(study_code: String!): Int @cypher(statement: "MATCH (c:case)-[*]->(sd:study) WHERE sd.clinical_study_designation = $study_code OR sd.accession_id = $study_code return count(distinct(c))")
-    fileCountOfCase(case_record_id: String!): Int @cypher(statement: "MATCH (f:file)-[*]->(c:case {case_record_id: $case_record_id}) return count(DISTINCT(f))")
-    studyFileCountOfCase(case_record_id: String!): Int @cypher(statement: "MATCH (c:case {case_record_id: $case_record_id}) OPTIONAL MATCH (c)-[:member_of]->(s:study) OPTIONAL MATCH (s)<--(f:file) return count(DISTINCT(f))")
-    aliquotCountOfCase(case_record_id: String!): Int @cypher(statement: "MATCH (a:aliquot)-[*]->(c:case {case_record_id: $case_record_id}) return count(DISTINCT(a))")
+    fileCountOfCase(case_id: String!): Int @cypher(statement: "MATCH (f:file)-[*]->(c:case {case_id: $case_id}) return count(DISTINCT(f))")
+    studyFileCountOfCase(case_id: String!): Int @cypher(statement: "MATCH (c:case {case_id: $case_id}) OPTIONAL MATCH (c)-[:member_of]->(s:study) OPTIONAL MATCH (s)<--(f:file) return count(DISTINCT(f))")
+    aliquotCountOfCase(case_id: String!): Int @cypher(statement: "MATCH (a:aliquot)-[*]->(c:case {case_id: $case_id}) return count(DISTINCT(a))")
     sampleCountOfProgram(program_id: String!): Int @cypher(statement: "MATCH (s:sample)-[*]->(:program {program_acronym: $program_id}) return count(DISTINCT(s))")
     fileCountOfProgram(program_id: String!): Int @cypher(statement: "MATCH (f:file)-[*]->(:program {program_acronym: $program_id}) return count(DISTINCT(f))")
     studyFileCountOfProgram(program_id: String!): Int @cypher(statement: "MATCH (s:study)-[*]->(:program {program_acronym: $program_id}) OPTIONAL MATCH (s) <-- (f:file) return count(DISTINCT(f))")
     aliquotCountOfProgram(program_id: String!): Int @cypher(statement: "MATCH (a:aliquot)-[*]->(:program {program_acronym: $program_id}) return count(DISTINCT(a))")
     studyCountOfProgram(program_id: String!): Int @cypher(statement: "MATCH (s:study)-[*]->(:program {program_acronym: $program_id}) WHERE s.study_disposition = 'Unrestricted' return count(DISTINCT(s))")
     caseCountOfProgram(program_id: String!): Int @cypher(statement: "MATCH (c:case)-[*]->(:program {program_acronym: $program_id}) return count(DISTINCT(c))")
-    sampleCountOfCase(case_record_id: String!): Int @cypher(statement: "MATCH (c:case {case_record_id: $case_record_id})<-[*]-(s:sample) RETURN count(distinct(s))")
+    sampleCountOfCase(case_id: String!): Int @cypher(statement: "MATCH (c:case {case_id: $case_id})<-[*]-(s:sample) RETURN count(distinct(s))")
 
     programCountOfStudy(study_code: String!): Int @cypher(statement: "MATCH (s:study {clinical_study_designation: $study_code}) OPTIONAL MATCH (s)-[:member_of]->(p: program)  return count(DISTINCT(p))")
-    programsCountOfCase(case_record_id: String!): Int @cypher(statement: "MATCH (c:case {case_record_id: $case_record_id}) OPTIONAL MATCH (c)-[:member_of]->(s:study) OPTIONAL MATCH (s)-[:member_of]->(p:program) return count(DISTINCT(p))")
+    programsCountOfCase(case_id: String!): Int @cypher(statement: "MATCH (c:case {case_id: $case_id}) OPTIONAL MATCH (c)-[:member_of]->(s:study) OPTIONAL MATCH (s)-[:member_of]->(p:program) return count(DISTINCT(p))")
 
     filesInList(uuids: [String], order_by: String = ""): [FileInList] @cypher(statement: """
     MATCH (f:file)
@@ -698,7 +698,7 @@ type QueryType {
     f.file_description AS file_description,
     f.file_format AS file_format,
     f.file_size AS file_size,
-    c.case_record_id AS case_record_id,
+    c.case_id AS case_id,
     demo.breed AS breed,
     diag.disease_term AS diagnosis,
     CASE WHEN s.clinical_study_designation IS NULL
@@ -740,7 +740,7 @@ type QueryType {
     diag.concurrent_disease_type AS concurrent_disease_type,
     co.cohort_description AS cohort_description,
     a.arm AS arm,
-    collect(DISTINCT o.case_record_id) AS other_cases,
+    collect(DISTINCT o.case_id) AS other_cases,
     'drs://nci-crdc.datacommons.io/dg.4DFC/' AS drs_prefix,
     f.file_location AS file_location,
     c.patient_id AS patient_id,
@@ -763,7 +763,7 @@ type QueryType {
     file_description: file_description,
     file_format: file_format,
     file_size: file_size,
-    case_record_id: case_record_id,
+    case_id: case_id,
     breed: breed,
     diagnosis: diagnosis,
     study_code: study_code,
@@ -828,7 +828,7 @@ type QueryType {
     WHEN 'file_description' THEN file_description
     WHEN 'file_format' THEN file_format
     WHEN 'file_size' THEN file_size
-    WHEN 'case_record_id' THEN case_record_id
+    WHEN 'case_id' THEN case_id
     WHEN 'breed' THEN breed
     WHEN 'diagnosis' THEN diagnosis
     WHEN 'study_code' THEN study_code
@@ -861,7 +861,7 @@ type QueryType {
     f.file_description AS file_description,
     f.file_format AS file_format,
     f.file_size AS file_size,
-    c.case_record_id AS case_record_id,
+    c.case_id AS case_id,
     demo.breed AS breed,
     diag.disease_term AS diagnosis,
     CASE WHEN s.clinical_study_designation IS NULL
@@ -903,7 +903,7 @@ type QueryType {
     diag.concurrent_disease_type AS concurrent_disease_type,
     co.cohort_description AS cohort_description,
     a.arm AS arm,
-    collect(DISTINCT o.case_record_id) AS other_cases,
+    collect(DISTINCT o.case_id) AS other_cases,
     'drs://nci-crdc.datacommons.io/dg.4DFC/' AS drs_prefix,
     f.file_location AS file_location,
     c.patient_id AS patient_id,
@@ -926,7 +926,7 @@ type QueryType {
     file_description: file_description,
     file_format: file_format,
     file_size: file_size,
-    case_record_id: case_record_id,
+    case_id: case_id,
     breed: breed,
     diagnosis: diagnosis,
     study_code: study_code,
@@ -991,7 +991,7 @@ type QueryType {
     WHEN 'file_description' THEN file_description
     WHEN 'file_format' THEN file_format
     WHEN 'file_size' THEN file_size
-    WHEN 'case_record_id' THEN case_record_id
+    WHEN 'case_id' THEN case_id
     WHEN 'breed' THEN breed
     WHEN 'diagnosis' THEN diagnosis
     WHEN 'study_code' THEN study_code
@@ -1081,8 +1081,8 @@ type QueryType {
     ORDER BY s.clinical_study_designation
     """, passThrough: true)
 
-    filesOfCase(case_record_id: String!): [FilesOfCase] @cypher(statement: """
-    MATCH (f:file)-[*]->(c:case{case_record_id: $case_record_id})
+    filesOfCase(case_id: String!): [FilesOfCase] @cypher(statement: """
+    MATCH (f:file)-[*]->(c:case{case_id: $case_id})
     WITH DISTINCT(f) AS f
     MATCH (f)-->(parent)
     RETURN{
@@ -1096,16 +1096,16 @@ type QueryType {
     uuid: f.uuid,
     file_location: f.file_location,
     parent: head(labels(parent)),
-    case_record_id: $case_record_id
+    case_id: $case_id
     }
     """, passThrough: true)
 
-    filesOfCases(case_record_ids: [String!]!): [FilesOfCase] @cypher(statement: """
+    filesOfCases(case_ids: [String!]!): [FilesOfCase] @cypher(statement: """
     MATCH (f:file)-[*]->(c:case)
     WITH
     DISTINCT(f) AS f,
     c MATCH (f)-->(parent)
-    WHERE c.case_record_id IN $case_record_ids
+    WHERE c.case_id IN $case_ids
     RETURN{
     file_status: f.file_status,
     file_name: f.file_name,
@@ -1117,12 +1117,12 @@ type QueryType {
     uuid: f.uuid,
     file_location: f.file_location,
     parent: head(labels(parent)),
-    case_record_id: c.case_record_id
+    case_id: c.case_id
     }
     """, passThrough: true)
 
-    multiStudyCases(case_record_id: String): MultiStudyCases @cypher(statement: """
-    MATCH (:case {case_record_id: $case_record_id})-->(i:canine_individual)
+    multiStudyCases(case_id: String): MultiStudyCases @cypher(statement: """
+    MATCH (:case {case_id: $case_id})-->(i:canine_individual)
     MATCH (i)<--(c:case)
     OPTIONAL MATCH (c)<--(samp:sample)
     OPTIONAL MATCH (c)<-[*]-(f:file)
@@ -1131,15 +1131,15 @@ type QueryType {
     WITH i, c, f, samp, sf
     RETURN{
     individualId: i.canine_individual_id,
-    caseRecordIds: collect(DISTINCT c.case_record_id),
+    caseIds: collect(DISTINCT c.case_id),
     sampleIds: collect(DISTINCT samp.sample_id),
     fileIds: collect(DISTINCT f.uuid),
     studyFileIds: collect(DISTINCT sf.uuid)
     }
     """, passThrough: true)
 
-    caseDetail(case_record_id: String): CaseDetail @cypher(statement: """
-    MATCH (c:case {case_record_id: $case_record_id})-->(s:study)-->(p:program)
+    caseDetail(case_id: String): CaseDetail @cypher(statement: """
+    MATCH (c:case {case_id: $case_id})-->(s:study)-->(p:program)
     OPTIONAL MATCH (c)-->(co:cohort)-->(a:study_arm)
     OPTIONAL MATCH (c)<--(demo:demographic)
     OPTIONAL MATCH (c)<--(diag:diagnosis)
@@ -1151,7 +1151,7 @@ type QueryType {
     arm: a.arm,
     ctep_treatment_assignment_code: a.ctep_treatment_assignment_code,
     cohort_description: co.cohort_description,
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     patient_id: c.patient_id,
     patient_first_name: c.patient_first_name,
     breed: demo.breed,
@@ -1215,7 +1215,7 @@ type QueryType {
     OPTIONAL MATCH (samp:sample)-[*]->(c)
     WITH DISTINCT c AS c, p, s, demo, diag, f, samp, prt
     RETURN{
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     study_code: s.clinical_study_designation,
     program: p.program_acronym,
     study_type: s.clinical_study_type,
@@ -1236,16 +1236,16 @@ type QueryType {
     }
     """, passThrough: true)
 
-    casesInList(case_record_ids: [String!]!): [CaseOverview] @cypher(statement: """
+    casesInList(case_ids: [String!]!): [CaseOverview] @cypher(statement: """
     MATCH
     (p:program)<-[*]-(s:study)<-[*]-(c:case)<--(demo:demographic),
     (c)<--(diag:diagnosis)
-    WHERE c.case_record_id IN $case_record_ids
+    WHERE c.case_id IN $case_ids
     OPTIONAL MATCH (f:file)-[*]->(c)
     OPTIONAL MATCH (samp:sample)-[*]->(c)
     WITH DISTINCT c AS c, p, s, demo, diag, f, samp
     RETURN{
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     study_code: s.clinical_study_designation,
     program: p.program_acronym,
     study_type: s.clinical_study_type,
@@ -1285,8 +1285,8 @@ type QueryType {
     RETURN DISTINCT(c)
     """)
 
-    samplesByCaseRecordId(case_record_id: String!): [sample] @cypher(statement: """
-    MATCH (c:case {case_record_id: $case_record_id})<-[*]-(s:sample)
+    samplesByCaseId(case_id: String!): [sample] @cypher(statement: """
+    MATCH (c:case {case_id: $case_id})<-[*]-(s:sample)
     RETURN s
     """)
 
@@ -1323,14 +1323,14 @@ type QueryType {
     OPTIONAL MATCH (f)-->(samp:sample)
     WITH DISTINCT (f) AS f, s, c, co, arm, demo, diag, v, samp,
     f.file_type as file_type,
-    c.case_record_id as case_record_id
+    c.case_id as case_id
     RETURN{
     clinical_study_designation: s.clinical_study_designation,
     clinical_study_name: s.clinical_study_name,
     arm: arm.arm,
     cohort_description: co.cohort_description,
     cohort_dose: co.cohort_dose,
-    case_record_id: case_record_id,
+    case_id: case_id,
     breed: demo.breed,
     weight: demo.weight,
     sex: demo.sex,
@@ -1368,7 +1368,7 @@ type QueryType {
     size: f.file_size,
     url: f.file_location
     }
-    ORDER BY file_type, case_record_id
+    ORDER BY file_type, case_id
     """, passThrough: true)
 
     "For IndexD to replace manifest"
@@ -1437,9 +1437,9 @@ type QueryType {
     ELSE file_name END DESC
     """, passThrough: true)
 
-    unifiedViewData(case_record_ids: [String] = [""]): UnifiedCounts @cypher(statement: """
+    unifiedViewData(case_ids: [String] = [""]): UnifiedCounts @cypher(statement: """
     MATCH (c:case)
-    WHERE ($case_record_ids = [""] OR $case_record_ids IS NULL OR c.case_record_id IN $case_record_ids)
+    WHERE ($case_ids = [""] OR $case_ids IS NULL OR c.case_id IN $case_ids)
     OPTIONAL MATCH (s:study)<--(c)
     OPTIONAL MATCH (f:file)-[*]->(c)
     OPTIONAL MATCH (samp:sample)-->(c)
@@ -1557,7 +1557,7 @@ type QueryType {
     OPTIONAL MATCH (v)<-[:on_visit]-(le:lab_exam)
     RETURN {
     agent: COUNT(DISTINCT a),
-    cycle: COUNT(DISTINCT cy.case_record_id),
+    cycle: COUNT(DISTINCT cy.case_id),
     visit: COUNT(DISTINCT left(v.visit_id, 13)),
     follow_up: COUNT(DISTINCT fu),
     adverse_event: COUNT(DISTINCT endNode(aeoc)),
@@ -1566,9 +1566,9 @@ type QueryType {
     prior_therapy: COUNT(DISTINCT pt),
     prior_surgery: COUNT(DISTINCT ps),
     agent_administration: COUNT(DISTINCT aa),
-    physical_exam: COUNT(DISTINCT pe.case_record_id),
-    vital_signs: COUNT(DISTINCT vs.case_record_id),
-    disease_extent: COUNT(DISTINCT de.case_record_id),
+    physical_exam: COUNT(DISTINCT pe.case_id),
+    vital_signs: COUNT(DISTINCT vs.case_id),
+    disease_extent: COUNT(DISTINCT de.case_id),
     lab_exam: COUNT(DISTINCT le)
     }
     """, passThrough: true)
@@ -1616,12 +1616,12 @@ type QueryType {
     MATCH (c)<-[*1..2]-(v:visit)
     WITH DISTINCT v, c
     RETURN {
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     visit_date: v.visit_date,
     visit_number: v.visit_number,
     visit_id: v.visit_id
     }
-    ORDER BY c.case_record_id
+    ORDER BY c.case_id
     """, passThrough: true)
 
     followUpNodeData(study_code: String!): [FollowUpNodeData] @cypher(statement: """
@@ -1639,7 +1639,7 @@ type QueryType {
     MATCH (c)<-[:of_case]-(ae:adverse_event)
     WITH DISTINCT ae, c
     RETURN {
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     day_in_cycle: ae.day_in_cycle,
     date_of_onset: ae.date_of_onset,
     existing_adverse_event: ae.existing_adverse_event,
@@ -1660,7 +1660,7 @@ type QueryType {
     dose_limiting_toxicity: ae.dose_limiting_toxicity,
     unexpected_adverse_event: ae.unexpected_adverse_event
     }
-    ORDER BY c.case_record_id
+    ORDER BY c.case_id
     """, passThrough: true)
 
     offTreatmentNodeData(study_code: String!): [OffTreatmentNodeData] @cypher(statement: """
@@ -1696,7 +1696,7 @@ type QueryType {
     MATCH (e)<-[:at_enrollment]-(ps:prior_surgery)
     WITH DISTINCT c, ps
     RETURN {
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     date_of_surgery: ps.date_of_surgery,
     procedure: ps.procedure,
     anatomical_site_of_surgery: ps.anatomical_site_of_surgery,
@@ -1704,7 +1704,7 @@ type QueryType {
     residual_disease: ps.residual_disease,
     therapeutic_indicator: ps.therapeutic_indicator
     }
-    ORDER BY c.case_record_id
+    ORDER BY c.case_id
     """, passThrough: true)
 
     agentAdministrationNodeData(study_code: String!): [AgentAdministrationNodeData] @cypher(statement: """
@@ -1724,7 +1724,7 @@ type QueryType {
     MATCH (v)<-[:on_visit]-(pe:physical_exam)
     WITH DISTINCT pe, c
     RETURN {
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     date_of_examination: pe.date_of_examination,
     day_in_cycle: pe.day_in_cycle,
     body_system: pe.body_system,
@@ -1733,7 +1733,7 @@ type QueryType {
     phase_pe: pe.phase_pe,
     assessment_timepoint: pe.assessment_timepoint
     }
-    ORDER BY c.case_record_id
+    ORDER BY c.case_id
     """, passThrough: true)
 
     vitalSignsNodeData(study_code: String!): [VitalSignsNodeData] @cypher(statement: """
@@ -1753,7 +1753,7 @@ type QueryType {
     MATCH (v)<-[:on_visit]-(de:disease_extent)
     WITH DISTINCT de, c
     RETURN {
-    case_record_id: c.case_record_id,
+    case_id: c.case_id,
     lesion_number: de.lesion_number,
     lesion_site: de.lesion_site,
     lesion_description: de.lesion_description,
@@ -1767,7 +1767,7 @@ type QueryType {
     evaluation_number: de.evaluation_number,
     evaluation_code: de.evaluation_code
     }
-    ORDER BY c.case_record_id
+    ORDER BY c.case_id
     """, passThrough: true)
 
     # labExamNodeData(study_code: String!): [LabExamNodeData] @cypher(statement: """
@@ -1786,12 +1786,12 @@ type QueryType {
     MATCH (c)<-[:of_case]-(e:enrollment)
     MATCH (e)<-[:at_enrollment]-(ps:prior_surgery)
     WITH DISTINCT c, ps
-    ORDER BY c.case_record_id
+    ORDER BY c.case_id
     RETURN
     {
       case_count: COUNT(DISTINCT c),
       prior_surgeries: collect({
-        case_record_id: c.case_record_id,
+        case_id: c.case_id,
         date_of_surgery: ps.date_of_surgery,
         procedure: ps.procedure,
         anatomical_site_of_surgery: ps.anatomical_site_of_surgery,

--- a/src/main/resources/yaml/es_indices_icdc.yml
+++ b/src/main/resources/yaml/es_indices_icdc.yml
@@ -69,14 +69,14 @@ Indices:
       file_format:
         type: keyword
 
-      case_record_ids:
+      case_ids:
         type: text
-      case_record_id_kw:
+      case_id_kw:
         type: keyword
         fields:
           analyzed:
             type: keyword
-      case_record_id_lc:
+      case_id_lc:
         type: keyword
 
       program_name:
@@ -156,9 +156,9 @@ Indices:
       'case' AS type,
       p.program_acronym AS program,
       p.program_name AS program_name,
-      c.case_record_id AS case_record_ids,
-      c.case_record_id AS case_record_id_kw,
-      toLower(c.case_record_id) AS case_record_id_lc,
+      c.case_id AS case_ids,
+      c.case_id AS case_id_kw,
+      toLower(c.case_id) AS case_id_lc,
       s.clinical_study_designation + ' ('+ s.accession_id+')' AS study,
       s.clinical_study_designation AS clinical_study_designation,
       s.clinical_study_designation AS study_code,
@@ -189,7 +189,7 @@ Indices:
       COLLECT(DISTINCT head(labels(parent))) + study_file_association AS file_association,
       COLLECT(DISTINCT f.file_type) + study_file_types AS file_type,
       COLLECT(DISTINCT f.file_format) + study_file_formats AS file_format,
-      COLLECT(DISTINCT o.case_record_id) AS other_cases,
+      COLLECT(DISTINCT o.case_id) AS other_cases,
       i.canine_individual_id as individual_id,
       diag.primary_disease_site as primary_disease_site,
       diag.date_of_diagnosis as date_of_diagnosis,
@@ -258,14 +258,14 @@ Indices:
       file_format:
         type: keyword
 
-      case_record_ids:
+      case_ids:
         type: keyword
         fields:
           analyzed:
             type: text
-      case_record_ids_txt:
+      case_ids_txt:
         type: text
-      case_record_id_lc:
+      case_id_lc:
         type: keyword
       sample_ids:
         type: keyword
@@ -408,9 +408,9 @@ Indices:
       COLLECT(DISTINCT f.file_type) + study_file_types AS file_type,
       COLLECT(DISTINCT f.file_format) + study_file_formats AS file_format,
 
-      c.case_record_id AS case_record_ids,
-      c.case_record_id AS case_record_ids_txt,
-      toLower(c.case_record_id) AS case_record_id_lc,
+      c.case_id AS case_ids,
+      c.case_id AS case_ids_txt,
+      toLower(c.case_id) AS case_id_lc,
       samp.sample_id AS sample_ids,
       samp.sample_id AS sample_ids_txt,
 
@@ -427,7 +427,7 @@ Indices:
       samp.comment as comment,
 
       i.canine_individual_id as individual_id,
-      COLLECT(DISTINCT o.case_record_id) AS other_cases,
+      COLLECT(DISTINCT o.case_id) AS other_cases,
       demo.patient_age_at_enrollment AS patient_age_at_enrollment,
       demo.neutered_indicator AS neutered_indicator,
       demo.weight AS weight,
@@ -489,14 +489,14 @@ Indices:
       file_level:
         type: keyword
 
-      case_record_ids:
+      case_ids:
         type: keyword
         fields:
           analyzed:
             type: text
-      case_record_ids_txt:
+      case_ids_txt:
         type: text
-      case_record_id_lc:
+      case_id_lc:
         type: keyword
       sample_ids:
         type: keyword
@@ -566,7 +566,7 @@ Indices:
         type: keyword
 
       # CASE
-      case_record_id:
+      case_id:
         type: keyword
       patient_id:
         type: keyword
@@ -759,10 +759,10 @@ Indices:
       f.file_location AS file_location,
       drs_prefix + file_uuid AS drs_uri,
 
-      COLLECT(DISTINCT c.case_record_id) AS case_record_ids,
-      COLLECT(DISTINCT c.case_record_id) AS case_record_ids_txt,
-      COLLECT(DISTINCT toLower(c.case_record_id)) AS case_record_id_lc,
-      COLLECT(DISTINCT c.case_record_id) AS case_record_id,
+      COLLECT(DISTINCT c.case_id) AS case_ids,
+      COLLECT(DISTINCT c.case_id) AS case_ids_txt,
+      COLLECT(DISTINCT toLower(c.case_id)) AS case_id_lc,
+      COLLECT(DISTINCT c.case_id) AS case_id,
       COLLECT(DISTINCT c.patient_id) AS patient_id,
       COLLECT(DISTINCT c.patient_first_name) AS patient_first_name,
       null AS sample_id,
@@ -875,10 +875,10 @@ Indices:
       f.file_location AS file_location,
       drs_prefix + file_uuid AS drs_uri,
 
-      c.case_record_id AS case_record_ids,
-      c.case_record_id AS case_record_ids_txt,
-      toLower(c.case_record_id) AS case_record_id_lc,
-      c.case_record_id AS case_record_id,
+      c.case_id AS case_ids,
+      c.case_id AS case_ids_txt,
+      toLower(c.case_id) AS case_id_lc,
+      c.case_id AS case_id,
       c.patient_id AS patient_id,
       c.patient_first_name AS patient_first_name,
       samp.sample_id AS sample_id,
@@ -926,7 +926,7 @@ Indices:
       diag.concurrent_disease_type as concurrent_disease_type,
       co.cohort_description AS cohort_description,
       a.arm as arm,
-      COLLECT(DISTINCT o.case_record_id) AS other_cases
+      COLLECT(DISTINCT o.case_id) AS other_cases
       "
 
   - index_name: programs


### PR DESCRIPTION
- [ICDC-4089](https://tracker.nci.nih.gov/browse/ICDC-4089)
- reverts the `case_record_id` migration (PRs #60 + #62)
- one commit contained schema file changes generated while the model converter was run from an incorrect model branch, which introduced unrelated schema churn 
- net effect is returning schemas to the pre-migration `case_id` contract