### PR TITLE
update tomcat version to avoid CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /usr/src/app
 COPY . .
 RUN mvn package -DskipTests
 # Stage 2: Production
-FROM tomcat:10.1.52-jdk17-temurin-jammy AS fnl_base_image
+FROM tomcat:10.1.54-jdk17-temurin-jammy AS fnl_base_image
 
 ENV JAVA_OPTS="-Xmx4096m"
 RUN apt-get update && apt-get install -y unzip

--- a/pom.xml
+++ b/pom.xml
@@ -125,12 +125,12 @@
 		<dependency>
 			<groupId>org.apache.tomcat.embed</groupId>
 			<artifactId>tomcat-embed-core</artifactId>
-			<version>10.1.52</version>
+			<version>10.1.54</version>
 		</dependency>
 		<dependency>
     		<groupId>org.apache.tomcat.embed</groupId>
     		<artifactId>tomcat-embed-jasper</artifactId>
-    		<version>10.1.52</version>
+    		<version>10.1.54</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.apache.tomcat.embed</groupId>


### PR DESCRIPTION
- Trivy scan failed due to CVEs in the Tomcat version (10.1.52)
- update Tomcat version to 10.1.54 so scan passes 