### PR TITLE
move ORDER BY clause to avoid neo4j-graphql-java bug

### DIFF
--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -1526,6 +1526,7 @@ type QueryType {
     COUNT(DISTINCT(c)) AS numberOfCases,
     COLLECT(DISTINCT ic{text: ic.image_collection_name + ' - ' + ic.repository_name,
     url: ic.image_collection_url}) AS CRDCLinks
+    ORDER BY s.clinical_study_designation
     RETURN{
     program_id: p.program_acronym,
     clinical_study_id: s.clinical_study_id,
@@ -1545,7 +1546,6 @@ type QueryType {
     numberOfCRDCNodes: numberOfCRDCNodes,
     CRDCLinks: CRDCLinks
     }
-    ORDER BY s.clinical_study_designation
     """, passThrough: true)
 
     studiesByProgram: [StudyOfProgram] @cypher(statement:"""
@@ -1565,6 +1565,7 @@ type QueryType {
     COUNT(DISTINCT(c)) AS numberOfCases,
     COLLECT(DISTINCT ic{text: ic.image_collection_name + ' - ' + ic.repository_name,
     url: ic.image_collection_url}) AS CRDCLinks
+    ORDER BY s.clinical_study_designation
     RETURN{
     program_id: p.program_acronym,
     clinical_study_id: s.clinical_study_id,
@@ -1584,7 +1585,6 @@ type QueryType {
     numberOfCRDCNodes: numberOfCRDCNodes,
     CRDCLinks: CRDCLinks
     }
-    ORDER BY s.clinical_study_designation
     """, passThrough: true)
 
     filesOfCase(case_id: String!): [FilesOfCase] @cypher(statement: """

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -1020,6 +1020,7 @@ type QueryType {
     COUNT(DISTINCT(c)) AS numberOfCases,
     COLLECT(DISTINCT ic{text: ic.image_collection_name + ' - ' + ic.repository_name,
     url: ic.image_collection_url}) AS CRDCLinks
+    ORDER BY s.clinical_study_designation
     RETURN{
     program_id: p.program_acronym,
     clinical_study_id: s.clinical_study_id,
@@ -1039,7 +1040,6 @@ type QueryType {
     numberOfCRDCNodes: numberOfCRDCNodes,
     CRDCLinks: CRDCLinks
     }
-    ORDER BY s.clinical_study_designation
     """, passThrough: true)
 
     studiesByProgram: [StudyOfProgram] @cypher(statement:"""
@@ -1059,6 +1059,7 @@ type QueryType {
     COUNT(DISTINCT(c)) AS numberOfCases,
     COLLECT(DISTINCT ic{text: ic.image_collection_name + ' - ' + ic.repository_name,
     url: ic.image_collection_url}) AS CRDCLinks
+    ORDER BY s.clinical_study_designation
     RETURN{
     program_id: p.program_acronym,
     clinical_study_id: s.clinical_study_id,
@@ -1078,7 +1079,6 @@ type QueryType {
     numberOfCRDCNodes: numberOfCRDCNodes,
     CRDCLinks: CRDCLinks
     }
-    ORDER BY s.clinical_study_designation
     """, passThrough: true)
 
     filesOfCase(case_id: String!): [FilesOfCase] @cypher(statement: """


### PR DESCRIPTION
**Note:** neo4j-graphql-java ORDER BY bug workaround

The studiesByProgram and studiesByProgramId queries in [icdc.graphql](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [icdc_queries.graphql](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) were modified to work around a bug in [neo4j-graphql-java](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) 1.x.

When the library processes a cypher directive, it appends AS <fieldName> to the last statement in the Cypher string to alias the result. If the last statement is an ORDER BY clause, this produces invalid Cypher such as:

`ORDER BY s.clinical_study_designation AS studiesByProgram`

AS is only valid in RETURN and WITH clauses in Cypher, not in ORDER BY.

The ORDER BY clause was moved from after the RETURN block to after the WITH/COLLECT block, which is valid Cypher. This makes RETURN {...} the last statement, so the library's appended alias produces:

`RETURN { ... } AS studiesByProgram`

which is valid. The sort order is preserved — only the position of the ORDER BY within the query changed.

This workaround was verified against neo4j-graphql-java versions 1.9.0 and 1.9.1; both exhibit the same behavior.