### PR TITLE
update sub-clause ordering within WITH statements

### DIFF
--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -1971,8 +1971,9 @@ type QueryType {
     WHERE s.clinical_study_designation in $study_codes OR s.accession_id in $study_codes
     OPTIONAL MATCH (c:case) --> (s)
     OPTIONAL MATCH (c) <-- (samp: sample)
-    WITH DISTINCT(samp.sample_site) AS group, COUNT(DISTINCT samp) AS counts where counts > 0
+    WITH DISTINCT(samp.sample_site) AS group, COUNT(DISTINCT samp) AS counts
     ORDER BY group
+    WHERE counts > 0
     RETURN {
     group: group,
     count: counts
@@ -1984,8 +1985,9 @@ type QueryType {
     WHERE s.clinical_study_designation in $study_codes OR s.accession_id in $study_codes
     OPTIONAL MATCH (c:case) --> (s)
     OPTIONAL MATCH (c) <-- (samp: sample)
-    WITH DISTINCT(samp.summarized_sample_type) AS group, COUNT(DISTINCT samp) AS counts where counts > 0
+    WITH DISTINCT(samp.summarized_sample_type) AS group, COUNT(DISTINCT samp) AS counts
     ORDER BY group
+    WHERE counts > 0
     RETURN {
     group: group,
     count: counts
@@ -1997,8 +1999,9 @@ type QueryType {
     WHERE s.clinical_study_designation in $study_codes OR s.accession_id in $study_codes
     OPTIONAL MATCH (c:case) --> (s)
     OPTIONAL MATCH (c) <-- (samp: sample)
-    WITH DISTINCT(samp.specific_sample_pathology) AS group, COUNT(DISTINCT samp) AS counts where counts > 0
+    WITH DISTINCT(samp.specific_sample_pathology) AS group, COUNT(DISTINCT samp) AS counts
     ORDER BY group
+    WHERE counts > 0
     RETURN {
     group: group,
     count: counts

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -1465,8 +1465,9 @@ type QueryType {
     WHERE s.clinical_study_designation in $study_codes OR s.accession_id in $study_codes
     OPTIONAL MATCH (c:case) --> (s)
     OPTIONAL MATCH (c) <-- (samp: sample)
-    WITH DISTINCT(samp.sample_site) AS group, COUNT(DISTINCT samp) AS counts where counts > 0
+    WITH DISTINCT(samp.sample_site) AS group, COUNT(DISTINCT samp) AS counts
     ORDER BY group
+    WHERE counts > 0
     RETURN {
     group: group,
     count: counts
@@ -1478,8 +1479,9 @@ type QueryType {
     WHERE s.clinical_study_designation in $study_codes OR s.accession_id in $study_codes
     OPTIONAL MATCH (c:case) --> (s)
     OPTIONAL MATCH (c) <-- (samp: sample)
-    WITH DISTINCT(samp.summarized_sample_type) AS group, COUNT(DISTINCT samp) AS counts where counts > 0
+    WITH DISTINCT(samp.summarized_sample_type) AS group, COUNT(DISTINCT samp) AS counts
     ORDER BY group
+    WHERE counts > 0
     RETURN {
     group: group,
     count: counts
@@ -1491,8 +1493,9 @@ type QueryType {
     WHERE s.clinical_study_designation in $study_codes OR s.accession_id in $study_codes
     OPTIONAL MATCH (c:case) --> (s)
     OPTIONAL MATCH (c) <-- (samp: sample)
-    WITH DISTINCT(samp.specific_sample_pathology) AS group, COUNT(DISTINCT samp) AS counts where counts > 0
+    WITH DISTINCT(samp.specific_sample_pathology) AS group, COUNT(DISTINCT samp) AS counts
     ORDER BY group
+    WHERE counts > 0
     RETURN {
     group: group,
     count: counts


### PR DESCRIPTION
- some of the queries updated to address the `neo4j-graphql-java` Cypher query aliasing bug had the ORDER BY sub-clauses incorrectly placed _after_ the WHERE clause (instead of directly after WITH), which was causing these queries to fail