### PR TITLE
file cart query bug fix caused by neo4j-graphql-java update

### DIFF
--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -1261,8 +1261,9 @@ type QueryType {
     diag.date_of_histology_confirmation AS date_of_histology_confirmation,
     co.cohort_dose AS cohort_dose,
     co.cohort_id AS cohort_id,
-    diag.diagnosis_id AS diagnosis_id
-    ORDER BY CASE $order_by
+    diag.diagnosis_id AS diagnosis_id,
+    order_by AS order_by
+    ORDER BY CASE order_by
     WHEN 'file_name' THEN file_name
     WHEN 'file_type' THEN file_type
     WHEN 'association' THEN association
@@ -1424,8 +1425,9 @@ type QueryType {
     diag.date_of_histology_confirmation AS date_of_histology_confirmation,
     co.cohort_dose AS cohort_dose,
     co.cohort_id AS cohort_id,
-    diag.diagnosis_id AS diagnosis_id
-    ORDER BY CASE $order_by
+    diag.diagnosis_id AS diagnosis_id,
+    order_by AS order_by
+    ORDER BY CASE order_by
     WHEN 'file_name' THEN file_name
     WHEN 'file_type' THEN file_type
     WHEN 'association' THEN association

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -755,8 +755,9 @@ type QueryType {
     diag.date_of_histology_confirmation AS date_of_histology_confirmation,
     co.cohort_dose AS cohort_dose,
     co.cohort_id AS cohort_id,
-    diag.diagnosis_id AS diagnosis_id
-    ORDER BY CASE $order_by
+    diag.diagnosis_id AS diagnosis_id,
+    order_by AS order_by
+    ORDER BY CASE order_by
     WHEN 'file_name' THEN file_name
     WHEN 'file_type' THEN file_type
     WHEN 'association' THEN association
@@ -918,8 +919,9 @@ type QueryType {
     diag.date_of_histology_confirmation AS date_of_histology_confirmation,
     co.cohort_dose AS cohort_dose,
     co.cohort_id AS cohort_id,
-    diag.diagnosis_id AS diagnosis_id
-    ORDER BY CASE $order_by
+    diag.diagnosis_id AS diagnosis_id,
+    order_by AS order_by
+    ORDER BY CASE order_by
     WHEN 'file_name' THEN file_name
     WHEN 'file_type' THEN file_type
     WHEN 'association' THEN association


### PR DESCRIPTION
[ICDC-4168](https://tracker.nci.nih.gov/browse/ICDC-4168)

```console
Uncaught (in promise) ApolloError: Exception while fetching data (/filesInList): 
In a WITH/RETURN with DISTINCT or an aggregation, 
it is not possible to access variables declared before the WITH/RETURN: 
order_by (line 81, column 15 (offset: 3160))
"ORDER BY CASE order_by"
```

- `neo4j-graphql-java` library prepends query parameters as Cypher variables before statement runs making `$order_by`--> `WITH $order_by AS order_by, ...` at the top, so `order_by` becomes a regular variable declared before the aggregating `WITH`