### PR TITLE
neo4j-graphql-java case resolver keyword collision workaround

### DIFF
--- a/src/main/resources/graphql/icdc.graphql
+++ b/src/main/resources/graphql/icdc.graphql
@@ -1158,7 +1158,7 @@ type QueryType {
     numberOfPrograms: Int @cypher(statement: "MATCH (n:program) RETURN count (n)")
     numberOfAliquots: Int @cypher(statement: "MATCH (n:aliquot) return count(n)")
     volumeOfData: Float @cypher(statement: "MATCH (f:file) WITH DISTINCT f return sum(f.file_size)")
-    volumeOfDataOfCase(case_id: String!): Float @cypher(statement: "MATCH (c:case{case_id: $case_id})-->(s:study) WITH s OPTIONAL MATCH (s)<--(f:file) WITH SUM(f.file_size) AS study_file_size OPTIONAL MATCH (c:case{case_id: $case_id})<-[*]-(f:file) with DISTINCT f, study_file_size RETURN SUM(f.file_size) + study_file_size")
+    volumeOfDataOfCase(case_id: String!): Float @cypher(statement: "MATCH (c:case{case_id: $case_id})-->(s:study) WITH s, c OPTIONAL MATCH (s)<--(f:file) WITH SUM(f.file_size) AS study_file_size, c OPTIONAL MATCH (c)<-[*]-(f:file) with DISTINCT f, study_file_size RETURN SUM(f.file_size) + study_file_size")
     volumeOfDataOfProgram(program_id: String!): Float @cypher(statement: "MATCH (f:file)-[*]->(:program {program_acronym: $program_id}) WITH DISTINCT f return sum(f.file_size)")
     volumeOfDataOfStudy(study_code: String!): Float @cypher(statement: "MATCH (f:file)-[*]->(:study {clinical_study_designation: $study_code}) WITH DISTINCT f return sum(f.file_size)")
 
@@ -1591,7 +1591,7 @@ type QueryType {
 
     filesOfCase(case_id: String!): [FilesOfCase] @cypher(statement: """
     MATCH (f:file)-[*]->(c:case{case_id: $case_id})
-    WITH DISTINCT(f) AS f
+    WITH DISTINCT(f) AS f, c
     MATCH (f)-->(parent)
     RETURN{
     file_status: f.file_status,
@@ -1604,16 +1604,15 @@ type QueryType {
     uuid: f.uuid,
     file_location: f.file_location,
     parent: head(labels(parent)),
-    case_id: $case_id
+    case_id: c.case_id
     }
     """, passThrough: true)
 
     filesOfCases(case_ids: [String!]!): [FilesOfCase] @cypher(statement: """
     MATCH (f:file)-[*]->(c:case)
-    WITH
-    DISTINCT(f) AS f,
-    c MATCH (f)-->(parent)
     WHERE c.case_id IN $case_ids
+    WITH DISTINCT(f) AS f, c
+    MATCH (f)-->(parent)
     RETURN{
     file_status: f.file_status,
     file_name: f.file_name,

--- a/src/main/resources/graphql/icdc_queries.graphql
+++ b/src/main/resources/graphql/icdc_queries.graphql
@@ -652,7 +652,7 @@ type QueryType {
     numberOfPrograms: Int @cypher(statement: "MATCH (n:program) RETURN count (n)")
     numberOfAliquots: Int @cypher(statement: "MATCH (n:aliquot) return count(n)")
     volumeOfData: Float @cypher(statement: "MATCH (f:file) WITH DISTINCT f return sum(f.file_size)")
-    volumeOfDataOfCase(case_id: String!): Float @cypher(statement: "MATCH (c:case{case_id: $case_id})-->(s:study) WITH s OPTIONAL MATCH (s)<--(f:file) WITH SUM(f.file_size) AS study_file_size OPTIONAL MATCH (c:case{case_id: $case_id})<-[*]-(f:file) with DISTINCT f, study_file_size RETURN SUM(f.file_size) + study_file_size")
+    volumeOfDataOfCase(case_id: String!): Float @cypher(statement: "MATCH (c:case{case_id: $case_id})-->(s:study) WITH s, c OPTIONAL MATCH (s)<--(f:file) WITH SUM(f.file_size) AS study_file_size, c OPTIONAL MATCH (c)<-[*]-(f:file) with DISTINCT f, study_file_size RETURN SUM(f.file_size) + study_file_size")
     volumeOfDataOfProgram(program_id: String!): Float @cypher(statement: "MATCH (f:file)-[*]->(:program {program_acronym: $program_id}) WITH DISTINCT f return sum(f.file_size)")
     volumeOfDataOfStudy(study_code: String!): Float @cypher(statement: "MATCH (f:file)-[*]->(:study {clinical_study_designation: $study_code}) WITH DISTINCT f return sum(f.file_size)")
 
@@ -1085,7 +1085,7 @@ type QueryType {
 
     filesOfCase(case_id: String!): [FilesOfCase] @cypher(statement: """
     MATCH (f:file)-[*]->(c:case{case_id: $case_id})
-    WITH DISTINCT(f) AS f
+    WITH DISTINCT(f) AS f, c
     MATCH (f)-->(parent)
     RETURN{
     file_status: f.file_status,
@@ -1098,16 +1098,15 @@ type QueryType {
     uuid: f.uuid,
     file_location: f.file_location,
     parent: head(labels(parent)),
-    case_id: $case_id
+    case_id: c.case_id
     }
     """, passThrough: true)
 
     filesOfCases(case_ids: [String!]!): [FilesOfCase] @cypher(statement: """
     MATCH (f:file)-[*]->(c:case)
-    WITH
-    DISTINCT(f) AS f,
-    c MATCH (f)-->(parent)
     WHERE c.case_id IN $case_ids
+    WITH DISTINCT(f) AS f, c
+    MATCH (f)-->(parent)
     RETURN{
     file_status: f.file_status,
     file_name: f.file_name,

--- a/src/test/java/gov/nih/nci/bento/graphql/CaseDataFetcherTest.java
+++ b/src/test/java/gov/nih/nci/bento/graphql/CaseDataFetcherTest.java
@@ -1,0 +1,90 @@
+package gov.nih.nci.bento.graphql;
+
+import graphql.schema.DataFetchingEnvironment;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.neo4j.driver.Driver;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Result;
+import org.neo4j.driver.Session;
+import org.neo4j.driver.Value;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CaseDataFetcherTest {
+
+    @Mock
+    private Driver driver;
+
+    @Mock
+    private Session session;
+
+    @Mock
+    private Result result;
+
+    @Mock
+    private DataFetchingEnvironment env;
+
+    @Mock
+    private Record record;
+
+    @Mock
+    private Value value;
+
+    @Test
+    void get_returnsSingleItemList_whenCaseExists_andUsesSafeCypherAlias() {
+        when(env.getArgument("case_id")).thenReturn("CASE-123");
+        when(driver.session()).thenReturn(session);
+        when(session.run(anyString(), anyMap())).thenReturn(result);
+        when(result.hasNext()).thenReturn(true);
+        when(result.next()).thenReturn(record);
+        when(record.get("c")).thenReturn(value);
+
+        Map<String, Object> caseNode = Map.of("case_id", "CASE-123");
+        when(value.asObject()).thenReturn(caseNode);
+
+        CaseDataFetcher fetcher = new CaseDataFetcher(driver);
+        Object fetched = fetcher.get(env);
+
+        assertInstanceOf(List.class, fetched);
+        List<?> asList = (List<?>) fetched;
+        assertEquals(1, asList.size());
+        assertEquals(caseNode, asList.get(0));
+
+        ArgumentCaptor<String> queryCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Map<String, Object>> paramCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(session).run(queryCaptor.capture(), paramCaptor.capture());
+        assertTrue(queryCaptor.getValue().contains("MATCH (c:case {case_id: $case_id})"));
+        assertFalse(queryCaptor.getValue().contains("MATCH (case:case"));
+        assertEquals("CASE-123", paramCaptor.getValue().get("case_id"));
+    }
+
+    @Test
+    void get_returnsEmptyList_whenCaseDoesNotExist() {
+        when(env.getArgument("case_id")).thenReturn("MISSING");
+        when(driver.session()).thenReturn(session);
+        when(session.run(anyString(), anyMap())).thenReturn(result);
+        when(result.hasNext()).thenReturn(false);
+
+        CaseDataFetcher fetcher = new CaseDataFetcher(driver);
+        Object fetched = fetcher.get(env);
+
+        assertInstanceOf(List.class, fetched);
+        List<?> asList = (List<?>) fetched;
+        assertTrue(asList.isEmpty());
+    }
+}


### PR DESCRIPTION
[ICDC-4179](https://tracker.nci.nih.gov/browse/ICDC-4179)

This PR fixes a runtime GraphQL failure caused by `neo4j-graphql-java` generating invalid Cypher for type `case`. The library uses the GraphQL type name as a Cypher node variable. For type `case`, it generates `case` as a variable name, which conflicts with the Cypher reserved keyword `CASE`. That breaks the auto-generated `case(case_id)` resolver path.

**Changes made:**

- Updates to Cypher queries to address `neo4j-graphql-java` 1.9.x parameter injection that caused values to be dropped at aggregating WITH boundaries
- Added a custom `CaseDataFetcher` for the `case(case_id)` query.
- Custom Cypher uses `c` as the node alias instead of `case`.
- Pre-fetched related `case` subfields and wired `PropertyDataFetcher` for those fields.
- Exposed Neo4j Driver from `AbstractNeo4jDataFetcher` for the custom fetcher.
- Added minimal unit tests for `CaseDataFetcher`:
  - returns one item when case exists
  - returns empty list when case is missing
  - verifies safe alias usage in query

**Reasoning:**

This keeps dependency/security updates in place while applying a targeted workaround for a known dependency issue.